### PR TITLE
Refactor sendEmail to accept options object

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,12 @@ export const resend: Resend = new Resend(components.resend, {});
 
 export const sendTestEmail = internalMutation({
   handler: async (ctx) => {
-    await resend.sendEmail(
-      ctx,
-      "Me <test@mydomain.com>",
-      "Resend <delivered@resend.dev>",
-      "Hi there",
-      "This is a test email"
-    );
+    await resend.sendEmail(ctx, {
+      from: "Me <test@mydomain.com>",
+      to: "Resend <delivered@resend.dev>",
+      subject: "Hi there",
+      html: "This is a test email",
+    });
   },
 });
 ```

--- a/example/convex/example.ts
+++ b/example/convex/example.ts
@@ -4,11 +4,7 @@ import {
   internalQuery,
 } from "./_generated/server";
 import { components, internal } from "./_generated/api";
-import {
-  vEmailId,
-  vEmailEvent,
-  Resend,
-} from "@convex-dev/resend";
+import { vEmailId, vEmailEvent, Resend } from "@convex-dev/resend";
 import { v } from "convex/values";
 
 export const resend: Resend = new Resend(components.resend, {
@@ -30,13 +26,12 @@ export const testBatch = internalAction({
     for (let i = 0; i < 25; i++) {
       const address = addresses[i % addresses.length];
       const expectation = address.split("@")[0];
-      const email = await resend.sendEmail(
-        ctx,
-        args.from,
-        address,
-        "Test Email",
-        "This is a test email"
-      );
+      const email = await resend.sendEmail(ctx, {
+        from: args.from,
+        to: address,
+        subject: "Test Email",
+        html: "This is a test email",
+      });
       await ctx.runMutation(internal.example.insertExpectation, {
         email: email,
         expectation: expectation as "delivered" | "bounced" | "complained",
@@ -95,7 +90,9 @@ export const handleEmailEvent = internalMutation({
         throw new Error("Email was delivered but expected to be bounced");
       }
       if (testEmail.expectation === "complained") {
-        console.log("Complained email was delivered, expecting complaint coming...");
+        console.log(
+          "Complained email was delivered, expecting complaint coming..."
+        );
         return;
       }
       // All good. Delivered email was delivered.

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -220,6 +220,7 @@ export class Resend {
     replyTo?: string[],
     headers?: { name: string; value: string }[]
   ): Promise<EmailId>;
+  /** @deprecated Use the object format e.g. `{ from, to, subject, html }` */
   async sendEmail(
     ctx: RunMutationCtx,
     fromOrOptions: string | SendEmailOptions,

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -126,6 +126,16 @@ export type EmailStatus = {
   opened: boolean;
 };
 
+export type SendEmailOptions = {
+  from: string;
+  to: string;
+  subject: string;
+  html?: string;
+  text?: string;
+  replyTo?: string[];
+  headers?: { name: string; value: string }[];
+};
+
 export class Resend {
   public config: Config;
   onEmailEvent?: FunctionReference<
@@ -163,7 +173,25 @@ export class Resend {
   }
 
   /**
-   * Sends an email.
+   * Sends an email by providing an object with all the email options. This is the recommended approach.
+   *
+   * Specifically, enqueues your email to be sent as part of efficient, durable email batches
+   * managed by the component. The email will be sent as soon as possible, but the component
+   * will manage rate limiting and batching for efficiency.
+   *
+   * This component utilizes idempotency keys to ensure the email is sent exactly once.
+   *
+   * @param ctx Any context that can run a mutation. You can enqueue an email from
+   * either a mutation or an action.
+   * @param options The {@link SendEmailOptions} object containing all email parameters.
+   * @returns The id of the email within the component.
+   */
+  async sendEmail(
+    ctx: RunMutationCtx,
+    options: SendEmailOptions
+  ): Promise<EmailId>;
+  /**
+   * Sends an email by providing individual arguments for `from`, `to`, `subject`, and optionally `html`, `text`, `replyTo`, and `headers`.
    *
    * Specifically, enqueues your email to be sent as part of efficient, durable email batches
    * managed by the component. The email will be sent as soon as possible, but the component
@@ -191,20 +219,37 @@ export class Resend {
     text?: string,
     replyTo?: string[],
     headers?: { name: string; value: string }[]
+  ): Promise<EmailId>;
+  async sendEmail(
+    ctx: RunMutationCtx,
+    fromOrOptions: string | SendEmailOptions,
+    to?: string,
+    subject?: string,
+    html?: string,
+    text?: string,
+    replyTo?: string[],
+    headers?: { name: string; value: string }[]
   ) {
-    if (this.config.apiKey === "") {
-      throw new Error("API key is not set");
-    }
+    const sendEmailArgs =
+      typeof fromOrOptions === "string"
+        ? {
+            from: fromOrOptions,
+            to: to!,
+            subject: subject!,
+            html,
+            text,
+            replyTo,
+            headers,
+          }
+        : fromOrOptions;
+
+    if (this.config.apiKey === "") throw new Error("API key is not set");
+
     const id = await ctx.runMutation(this.component.lib.sendEmail, {
       options: await configToRuntimeConfig(this.config, this.onEmailEvent),
-      from,
-      to,
-      subject,
-      html,
-      text,
-      replyTo,
-      headers,
+      ...sendEmailArgs,
     });
+
     return id as EmailId;
   }
 

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -173,7 +173,7 @@ export class Resend {
   }
 
   /**
-   * Sends an email by providing an object with all the email options. This is the recommended approach.
+   * Sends an email
    *
    * Specifically, enqueues your email to be sent as part of efficient, durable email batches
    * managed by the component. The email will be sent as soon as possible, but the component


### PR DESCRIPTION
Updated the Resend.sendEmail method to support an options object for email parameters, improving flexibility and clarity. Refactored usage in example and documentation to use the new object-based signature. Added SendEmailOptions type and updated method overloads and implementation accordingly.