### PR TITLE
fix lodash type errors, switch to remeda

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
   "devDependencies": {
     "@edge-runtime/vm": "^5.0.0",
     "@eslint/js": "^9.9.1",
-    "@types/lodash": "^4.17.17",
     "@types/node": "^18.17.0",
     "chokidar-cli": "^3.0.0",
     "convex-test": "^0.0.33",
@@ -88,7 +87,7 @@
   "dependencies": {
     "@convex-dev/rate-limiter": "^0.2.10",
     "@convex-dev/workpool": "^0.2.10",
-    "lodash": "^4.17.21",
+    "remeda": "^2.26.0",
     "svix": "^1.67.0"
   }
 }

--- a/src/component/lib.ts
+++ b/src/component/lib.ts
@@ -13,9 +13,9 @@ import { components, internal } from "./_generated/api";
 import { internalMutation } from "./_generated/server";
 import { Id, Doc } from "./_generated/dataModel";
 import { RuntimeConfig, vOptions, vStatus } from "./shared";
-import _ from "lodash";
 import { FunctionHandle } from "convex/server";
 import { EmailEvent, RunMutationCtx } from "./shared";
+import { isDeepEqual } from "remeda";
 
 // Move some of these to options? TODO
 const SEGMENT_MS = 125;
@@ -219,7 +219,7 @@ async function scheduleBatchRun(ctx: MutationCtx, options: RuntimeConfig) {
     await ctx.db.insert("lastOptions", {
       options,
     });
-  } else if (!_.isEqual(lastOptions.options, options)) {
+  } else if (!isDeepEqual(lastOptions.options, options)) {
     await ctx.db.replace(lastOptions._id, {
       options,
     });


### PR DESCRIPTION
Ran into this while implementing the Resend component in the Better Auth component.
<img width="790" height="208" alt="Screenshot 2025-07-16 at 3 58 31 PM" src="https://github.com/user-attachments/assets/0ebab1d4-e402-44b0-8ec7-106609c85e2c" />

I'm sure there's some sort of solution, but Remeda works great and is TypeScript first, so this is a no fuss option.
----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
