### PR TITLE
Fix Status comment block

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -107,6 +107,7 @@ export type EmailStatus = {
    * The status of the email. It will be one of the following:
    * - `waiting`: The email has not yet been batched.
    * - `queued`: The email has been batched and is waiting to be sent.
+   * - `cancelled`: The email has been cancelled.
    * - `sent`: The email has been sent to Resend, but we do not yet know its fate.
    * - `bounced`: The email bounced.
    * - `delivered`: The email was delivered successfully.


### PR DESCRIPTION
Corrected Status comment block to accurately represent the type of `Status`.

As per `shared.ts` [Line 14](https://github.com/get-convex/resend/blob/b3f0a122c36c35d6f459a2f4bcf8999770e9682e/src/component/shared.ts#L14)
```ts
export const vStatus = v.union(
  v.literal("waiting"),
  v.literal("queued"),
  v.literal("cancelled"),
  v.literal("sent"),
  v.literal("delivered"),
  v.literal("delivery_delayed"),
  v.literal("bounced")
);
```

<!-- Describe your PR here. -->



<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
