### PR TITLE
Click Handling (opt-in)

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -30,6 +30,7 @@ function getDefaultConfig(): Config {
     initialBackoffMs: 30000,
     retryAttempts: 5,
     testMode: true,
+    handleClick: false,
   };
 }
 
@@ -78,6 +79,12 @@ export type ResendOptions = {
       event: EmailEvent;
     }
   > | null;
+
+  /**
+   * Whether to store email.clicked events.
+   * Default: false
+   */
+  handleClick?: boolean;
 };
 
 async function configToRuntimeConfig(
@@ -171,6 +178,7 @@ export class Resend {
         options?.initialBackoffMs ?? defaultConfig.initialBackoffMs,
       retryAttempts: options?.retryAttempts ?? defaultConfig.retryAttempts,
       testMode: options?.testMode ?? defaultConfig.testMode,
+      handleClick: options?.handleClick ?? defaultConfig.handleClick,
     };
     if (options?.onEmailEvent) {
       this.onEmailEvent = options.onEmailEvent;

--- a/src/component/schema.ts
+++ b/src/component/schema.ts
@@ -15,6 +15,13 @@ export default defineSchema({
   lastOptions: defineTable({
     options: vOptions,
   }),
+  emailClicks: defineTable({
+    emailId: v.id("emails"),
+    ipAddress: v.string(),
+    link: v.string(),
+    timestamp: v.string(),
+    userAgent: v.string(),
+  }),
   emails: defineTable({
     from: v.string(),
     to: v.string(),
@@ -30,6 +37,7 @@ export default defineSchema({
         })
       )
     ),
+    clicks: v.array(v.id("emailClicks")),
     status: vStatus,
     errorMessage: v.optional(v.string()),
     complained: v.boolean(),

--- a/src/component/schema.ts
+++ b/src/component/schema.ts
@@ -21,7 +21,8 @@ export default defineSchema({
     link: v.string(),
     timestamp: v.string(),
     userAgent: v.string(),
-  }),
+  })
+    .index("by_emailId", ["emailId"]),
   emails: defineTable({
     from: v.string(),
     to: v.string(),

--- a/src/component/shared.ts
+++ b/src/component/shared.ts
@@ -29,9 +29,19 @@ export const vOptions = v.object({
   apiKey: v.string(),
   testMode: v.boolean(),
   onEmailEvent: v.optional(onEmailEvent),
+  handleClick: v.optional(v.boolean()),
 });
 
 export type RuntimeConfig = Infer<typeof vOptions>;
+
+export const vClickEvent = v.object({
+  ipAddress: v.string(),
+  link: v.string(),
+  timestamp: v.string(),
+  userAgent: v.string(),
+});
+
+export type ClickEvent = Infer<typeof vClickEvent>;
 
 // Normalized webhook events coming from Resend.
 export const vEmailEvent = v.object({
@@ -43,6 +53,7 @@ export const vEmailEvent = v.object({
         message: v.optional(v.string()),
       })
     ),
+    click: v.optional(vClickEvent),
   }),
 });
 export type EmailEvent = Infer<typeof vEmailEvent>;


### PR DESCRIPTION
<!-- Describe your PR here. -->
This is a PR for Issue #4 

Adds opt-in support for `email.clicked` events (defaults to `false`).

[As per Resend Docs](https://resend.com/docs/dashboard/webhooks/event-types#email-clicked)
```typescript
"click": {
      "ipAddress": "122.115.53.11", // string
      "link": "https://resend.com", // string
      "timestamp": "2024-11-24T05:00:57.163Z", // string
      "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.1 Safari/605.1.15" // string
}
```

Saves click event data in `emailClicks` 

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
