### PR TITLE
chore: extend types to include all keys from resend and pass original event to callback

### DIFF
--- a/src/component/lib.ts
+++ b/src/component/lib.ts
@@ -630,12 +630,6 @@ export const handleEmailEvent = mutation({
       console.info(`Email not found for resendId: ${resendId}, ignoring...`);
       return;
     }
-    const cleanedEvent: EmailEvent = {
-      type: event.type,
-      data: {
-        email_id: resendId,
-      },
-    };
     let changed = true;
     switch (event.type) {
       case "email.sent":
@@ -650,7 +644,7 @@ export const handleEmailEvent = mutation({
         email.status = "bounced";
         email.finalizedAt = Date.now();
         email.errorMessage = event.data.bounce?.message;
-        cleanedEvent.data.bounce = {
+        event.data.bounce = {
           message: event.data.bounce?.message,
         };
         break;
@@ -675,7 +669,7 @@ export const handleEmailEvent = mutation({
     if (changed) {
       await ctx.db.replace(email._id, email);
     }
-    await enqueueCallbackIfExists(ctx, email, cleanedEvent);
+    await enqueueCallbackIfExists(ctx, email, event);
   },
 });
 

--- a/src/component/shared.ts
+++ b/src/component/shared.ts
@@ -34,18 +34,84 @@ export const vOptions = v.object({
 
 export type RuntimeConfig = Infer<typeof vOptions>;
 
-// Normalized webhook events coming from Resend.
-export const vEmailEvent = v.object({
-  type: v.string(),
-  data: v.object({
-    email_id: v.string(),
-    bounce: v.optional(
+const vEmailEventData = v.object({
+  email_id: v.string(),
+  broadcast_id: v.optional(v.string()),
+  from: v.optional(v.string()),
+  to: v.optional(v.array(v.string())),
+  subject: v.optional(v.string()),
+  tags: v.optional(
+    v.array(
       v.object({
-        message: v.optional(v.string()),
+        name: v.string(),
+        value: v.string(),
       })
-    ),
-  }),
+    )
+  ),
 });
+
+export const vEmailEvent = v.union(
+  v.object({
+    type: v.literal("email.sent"),
+    data: vEmailEventData,
+  }),
+  v.object({
+    type: v.literal("email.delivered"),
+    data: vEmailEventData,
+  }),
+  v.object({
+    type: v.literal("email.delivery_delayed"),
+    data: vEmailEventData,
+  }),
+  v.object({
+    type: v.literal("email.complained"),
+    data: vEmailEventData,
+  }),
+  v.object({
+    type: v.literal("email.opened"),
+    data: vEmailEventData,
+  }),
+  v.object({
+    type: v.literal("email.bounced"),
+    data: v.object({
+      ...vEmailEventData.fields,
+      bounce: v.optional(
+        v.object({
+          message: v.optional(v.string()),
+          subType: v.optional(v.string()),
+          type: v.optional(v.string()),
+        })
+      ),
+    }),
+  }),
+  v.object({
+    type: v.literal("email.clicked"),
+    data: v.object({
+      ...vEmailEventData.fields,
+      click: v.optional(
+        v.object({
+          link: v.optional(v.string()),
+          ipAddress: v.optional(v.string()),
+          timestamp: v.optional(v.string()),
+          userAgent: v.optional(v.string()),
+        })
+      ),
+    }),
+  }),
+  v.object({
+    type: v.literal("email.failed"),
+    created_at: v.string(),
+    data: v.object({
+      ...vEmailEventData.fields,
+      failed: v.optional(
+        v.object({
+          reason: v.optional(v.string()),
+        })
+      ),
+    }),
+  })
+);
+
 export type EmailEvent = Infer<typeof vEmailEvent>;
 
 /* Type utils follow */


### PR DESCRIPTION
Improving the types for vEmailEvent to use string literals for event.type and unions for objects for better type safety.

Also passing the original event onto the callback instead of a "cleaned" event that strips most of the event payload.
