### PR TITLE
fixes for defineOnEmailEvent

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,12 +126,14 @@ export const resend: Resend = new Resend(components.resend, {
   onEmailEvent: internal.example.handleEmailEvent,
 });
 
-export const handleEmailEvent = resend.defineOnEmailEvent(async (ctx, args) => {
-  console.log("Got called back!", args.id, args.event);
-  // Probably do something with the event if you care about deliverability!
+export const handleEmailEvent = internalMutation({
+  args: vOnEmailEventArgs,
+  handler: async (ctx, args) => {
+    // Handle however you want
+    // args provides { id: EmailId; event: EmailEvent; }
+    // see /example/example.ts
+  },
 });
-
-/* ... existing email sending code ... */
 ```
 
 Check out the `example/` project in this repo for a full demo.

--- a/example/convex/example.ts
+++ b/example/convex/example.ts
@@ -4,7 +4,7 @@ import {
   internalQuery,
 } from "./_generated/server";
 import { components, internal } from "./_generated/api";
-import { vEmailId, vEmailEvent, Resend } from "@convex-dev/resend";
+import { Resend, vOnEmailEventArgs } from "@convex-dev/resend";
 import { v } from "convex/values";
 
 export const resend: Resend = new Resend(components.resend, {
@@ -94,10 +94,7 @@ export const isEmpty = internalQuery({
 });
 
 export const handleEmailEvent = internalMutation({
-  args: {
-    id: vEmailId,
-    event: vEmailEvent,
-  },
+  args: vOnEmailEventArgs,
   handler: async (ctx, args) => {
     console.log("Got called back!", args.id, args.event);
     const testEmail = await ctx.db

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.0.0",
       "dependencies": {
         "@convex-dev/resend": "file:..",
-        "@convex-dev/workpool": "^0.2.17",
         "convex": "^1.24.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
@@ -25,11 +24,11 @@
     },
     "..": {
       "name": "@convex-dev/resend",
-      "version": "0.1.5-alpha.0",
+      "version": "0.1.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@convex-dev/rate-limiter": "^0.2.10",
-        "@convex-dev/workpool": "^0.2.10",
+        "@convex-dev/workpool": "^0.2.17",
         "remeda": "^2.26.0",
         "svix": "^1.67.0"
       },
@@ -58,16 +57,6 @@
     "node_modules/@convex-dev/resend": {
       "resolved": "..",
       "link": true
-    },
-    "node_modules/@convex-dev/workpool": {
-      "version": "0.2.17",
-      "resolved": "https://registry.npmjs.org/@convex-dev/workpool/-/workpool-0.2.17.tgz",
-      "integrity": "sha512-Z2GjubsieZATdLYip+WTRLQNRmo+Jl9OoeN0GjsgIhLriHrNyddijosgGH656LtdmVs4SdqyqkwvMwabRixakA==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "convex": ">=1.25.0 <1.35.0",
-        "convex-helpers": "^0.1.94"
-      }
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.4",
@@ -1193,41 +1182,6 @@
         }
       }
     },
-    "node_modules/convex-helpers": {
-      "version": "0.1.99",
-      "resolved": "https://registry.npmjs.org/convex-helpers/-/convex-helpers-0.1.99.tgz",
-      "integrity": "sha512-W4sV9676vWWIwfYvG76Dxf7biDgpYggvwTLW5fJgLhXIb/XUCacO2AOXu+HrW85GvPRb1LLjhWgWPH8byHiTsw==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "bin": {
-        "convex-helpers": "bin.cjs"
-      },
-      "peerDependencies": {
-        "@standard-schema/spec": "^1.0.0",
-        "convex": "^1.13.0",
-        "hono": "^4.0.5",
-        "react": "^17.0.2 || ^18.0.0 || ^19.0.0",
-        "typescript": "^5.5",
-        "zod": "^3.22.4"
-      },
-      "peerDependenciesMeta": {
-        "@standard-schema/spec": {
-          "optional": true
-        },
-        "hono": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "typescript": {
-          "optional": true
-        },
-        "zod": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2216,7 +2170,7 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,5 +1,7 @@
 import {
   createFunctionHandle,
+  GenericDataModel,
+  GenericMutationCtx,
   internalMutationGeneric,
   type Expand,
   type FunctionReference,
@@ -23,6 +25,10 @@ export type EmailId = string & { __isEmailId: true };
 export const vEmailId = v.string() as VString<EmailId>;
 export { vEmailEvent, vStatus, vOptions } from "../component/shared.js";
 export type { Status, EmailEvent } from "../component/shared.js";
+export const vOnEmailEventArgs = v.object({
+  id: vEmailId,
+  event: vEmailEvent,
+});
 
 type Config = RuntimeConfig & {
   webhookSecret: string;
@@ -369,12 +375,16 @@ export class Resend {
   /**
    * Defines a mutation to run after an email event occurs.
    *
+   * It is probably simpler to just define your mutation as a `internalMutation`
+   * and pass the `vOnEmailEventArgs` as the args than use this.
+   * See the example in the README for more.
+   *
    * @param handler The handler to run after an email event occurs.
    * @returns The mutation to run after an email event occurs.
    */
-  async defineOnEmailEvent(
+  defineOnEmailEvent<DataModel extends GenericDataModel>(
     handler: (
-      ctx: RunMutationCtx,
+      ctx: GenericMutationCtx<DataModel>,
       args: { id: EmailId; event: EmailEvent }
     ) => Promise<void>
   ) {


### PR DESCRIPTION
This PR does a couple of things: 

1. removes the "async" requirement from `defineOnEmailEvent` which im pretty sure was a mistake
2. adds a `vOnEmailEventArgs` validator so the user can define their own handler rather than using `defineOnEmailEvent`. This is how it is done in the example.

Based on chat with ian we are not going to recommend that users use defineOnEmailEvent any more and are instead going to suggest that they just define their own mutation and typed args for that instead. 

I have updated the README to reflect this.
