### PR TITLE
Mikec/fixing handle email event issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@convex-dev/rate-limiter": "^0.2.10",
         "@convex-dev/workpool": "^0.2.17",
         "remeda": "^2.26.0",
-        "svix": "^1.67.0"
+        "svix": "^1.70.0"
       },
       "devDependencies": {
         "@edge-runtime/vm": "^5.0.0",
@@ -4220,9 +4220,9 @@
       }
     },
     "node_modules/svix": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/svix/-/svix-1.67.0.tgz",
-      "integrity": "sha512-VTGUNrf7nvBYuB0n82Igg9PEVOcfriecKLVTGN9l3dY/6yEzV+j4leOppfR1twFzoODA6DJI1+spg/QJ4NKtLg==",
+      "version": "1.70.0",
+      "resolved": "https://registry.npmjs.org/svix/-/svix-1.70.0.tgz",
+      "integrity": "sha512-ZrYvUoHPPtzp+C3t5c2hvMMleeZL7teFMigt6u/gdlpEKyPopeX74eMJuHtuPixB+nB24gfWJ1W1N3B5ZZ+AJw==",
       "license": "MIT",
       "dependencies": {
         "@stablelib/base64": "^1.0.0",
@@ -4230,7 +4230,8 @@
         "es6-promise": "^4.2.8",
         "fast-sha256": "^1.3.0",
         "svix-fetch": "^3.0.0",
-        "url-parse": "^1.5.10"
+        "url-parse": "^1.5.10",
+        "uuid": "^10.0.0"
       }
     },
     "node_modules/svix-fetch": {
@@ -4563,6 +4564,19 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/validate-npm-package-name": {

--- a/package.json
+++ b/package.json
@@ -79,6 +79,6 @@
     "@convex-dev/rate-limiter": "^0.2.10",
     "@convex-dev/workpool": "^0.2.17",
     "remeda": "^2.26.0",
-    "svix": "^1.67.0"
+    "svix": "^1.70.0"
   }
 }

--- a/src/client/_generated/_ignore.ts
+++ b/src/client/_generated/_ignore.ts
@@ -1,0 +1,1 @@
+// This is only here so convex-test can detect a _generated folder

--- a/src/client/index.test.ts
+++ b/src/client/index.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, test } from "vitest";
+import {
+  components,
+  componentSchema,
+  componentModules,
+  modules,
+} from "./setup.test.js";
+import { defineSchema } from "convex/server";
+import { convexTest } from "convex-test";
+import { type EmailId, Resend } from "./index.js";
+
+const schema = defineSchema({});
+
+function setupTest() {
+  const t = convexTest(schema, modules);
+  t.registerComponent("resend", componentSchema, componentModules);
+  const resend = new Resend(components.resend, {});
+  return { t, resend };
+}
+
+type ConvexTest = ReturnType<typeof setupTest>["t"];
+
+describe("TableAggregate", () => {
+  describe("status", () => {
+    let t: ConvexTest;
+    let resend: Resend;
+
+    beforeEach(() => {
+      ({ resend, t } = setupTest());
+    });
+
+    const exec = async () => {
+      return await t.run(async (ctx) => {
+        return await resend.status(ctx, "123" as EmailId);
+      });
+    };
+
+    test("should count zero items in empty table", async () => {
+      const result = await exec();
+      expect(result).toBe(0);
+    });
+  });
+});

--- a/src/client/index.test.ts
+++ b/src/client/index.test.ts
@@ -20,7 +20,7 @@ function setupTest() {
 
 type ConvexTest = ReturnType<typeof setupTest>["t"];
 
-describe("TableAggregate", () => {
+describe("Resend", () => {
   describe("status", () => {
     let t: ConvexTest;
     let resend: Resend;

--- a/src/client/index.test.ts
+++ b/src/client/index.test.ts
@@ -1,43 +1,18 @@
-import { beforeEach, describe, expect, test } from "vitest";
-import {
-  components,
-  componentSchema,
-  componentModules,
-  modules,
-} from "./setup.test.js";
+import { describe, test } from "vitest";
+import { componentSchema, componentModules, modules } from "./setup.test.js";
 import { defineSchema } from "convex/server";
 import { convexTest } from "convex-test";
-import { type EmailId, Resend } from "./index.js";
 
 const schema = defineSchema({});
 
 function setupTest() {
   const t = convexTest(schema, modules);
   t.registerComponent("resend", componentSchema, componentModules);
-  const resend = new Resend(components.resend, {});
-  return { t, resend };
+  return { t };
 }
 
 type ConvexTest = ReturnType<typeof setupTest>["t"];
 
 describe("Resend", () => {
-  describe("status", () => {
-    let t: ConvexTest;
-    let resend: Resend;
-
-    beforeEach(() => {
-      ({ resend, t } = setupTest());
-    });
-
-    const exec = async () => {
-      return await t.run(async (ctx) => {
-        return await resend.status(ctx, "123" as EmailId);
-      });
-    };
-
-    test("should count zero items in empty table", async () => {
-      const result = await exec();
-      expect(result).toBe(0);
-    });
-  });
+  test("handleResendEventWebhook", async () => {});
 });

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -19,7 +19,7 @@ import {
   type RunQueryCtx,
 } from "../component/shared.js";
 
-export type UsedAPI = UseApi<typeof api>;
+export type ResendComponent = UseApi<typeof api>;
 
 export type EmailId = string & { __isEmailId: true };
 export const vEmailId = v.string() as VString<EmailId>;

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -19,6 +19,8 @@ import {
   type RunQueryCtx,
 } from "../component/shared.js";
 
+export type UsedAPI = UseApi<typeof api>;
+
 export type EmailId = string & { __isEmailId: true };
 export const vEmailId = v.string() as VString<EmailId>;
 export { vEmailEvent, vStatus, vOptions } from "../component/shared.js";

--- a/src/client/setup.test.ts
+++ b/src/client/setup.test.ts
@@ -6,12 +6,12 @@ export const modules = import.meta.glob("./**/*.*s");
 export { componentSchema };
 export const componentModules = import.meta.glob("../component/**/*.ts");
 
-import { type UsedAPI } from "./index.js";
+import { type ResendComponent } from "./index.js";
 import { componentsGeneric } from "convex/server";
 import componentSchema from "../component/schema.js";
 
 export const components = componentsGeneric() as unknown as {
-  resend: UsedAPI;
+  resend: ResendComponent;
 };
 
 test("setup", () => {});

--- a/src/client/setup.test.ts
+++ b/src/client/setup.test.ts
@@ -1,0 +1,17 @@
+/// <reference types="vite/client" />
+
+import { test } from "vitest";
+
+export const modules = import.meta.glob("./**/*.*s");
+export { componentSchema };
+export const componentModules = import.meta.glob("../component/**/*.ts");
+
+import { type UsedAPI } from "./index.js";
+import { componentsGeneric } from "convex/server";
+import componentSchema from "../component/schema.js";
+
+export const components = componentsGeneric() as unknown as {
+  resend: UsedAPI;
+};
+
+test("setup", () => {});

--- a/src/component/lib.test.ts
+++ b/src/component/lib.test.ts
@@ -2,7 +2,7 @@ import { expect, describe, it, beforeEach } from "vitest";
 import { api } from "./_generated/api.js";
 import type { EmailEvent } from "./shared.js";
 import {
-  createTestDeliveredEvent,
+  createTestEventOfType,
   insertTestSentEmail,
   setupTest,
   setupTestLastOptions,
@@ -17,12 +17,12 @@ describe("handleEmailEvent", () => {
 
   beforeEach(async () => {
     t = setupTest();
-    event = createTestDeliveredEvent();
+    event = createTestEventOfType("email.delivered");
     await setupTestLastOptions(t);
     email = await insertTestSentEmail(t);
   });
 
-  const exec = (_event = event) =>
+  const exec = (_event: EmailEvent | unknown = event) =>
     t.mutation(api.lib.handleEmailEvent, { event: _event });
 
   const getEmail = () =>
@@ -45,12 +45,168 @@ describe("handleEmailEvent", () => {
 
   it("updates email for complained event", async () => {
     expect(email.status).toBe("sent");
-    event.type = "email.complained";
+    event = createTestEventOfType("email.complained");
 
     await exec();
 
     const updatedEmail = await getEmail();
     expect(updatedEmail.status).toBe("sent");
     expect(updatedEmail.complained).toBe(true);
+  });
+
+  it("updates email for bounced event", async () => {
+    expect(email.status).toBe("sent");
+    event = createTestEventOfType("email.bounced");
+
+    await exec();
+
+    const updatedEmail = await getEmail();
+    expect(updatedEmail.status).toBe("bounced");
+    expect(updatedEmail.finalizedAt).toBeLessThan(Number.MAX_SAFE_INTEGER);
+    expect(updatedEmail.finalizedAt).toBeGreaterThan(Date.now() - 10000); // Within last 10 seconds
+    expect(updatedEmail.errorMessage).toBe(
+      "The email bounced due to invalid recipient"
+    );
+  });
+
+  it("updates email for delivery_delayed event", async () => {
+    expect(email.status).toBe("sent");
+    event = createTestEventOfType("email.delivery_delayed");
+
+    await exec();
+
+    const updatedEmail = await getEmail();
+    expect(updatedEmail.status).toBe("delivery_delayed");
+    expect(updatedEmail.finalizedAt).toBe(Number.MAX_SAFE_INTEGER); // Should remain unchanged
+  });
+
+  it("updates email for opened event", async () => {
+    expect(email.status).toBe("sent");
+    expect(email.opened).toBe(false);
+    event = createTestEventOfType("email.opened");
+
+    await exec();
+
+    const updatedEmail = await getEmail();
+    expect(updatedEmail.status).toBe("sent");
+    expect(updatedEmail.opened).toBe(true);
+  });
+
+  it("does not update email for sent event", async () => {
+    expect(email.status).toBe("sent");
+    event = createTestEventOfType("email.sent");
+
+    await exec();
+
+    const updatedEmail = await getEmail();
+    expect(updatedEmail.status).toBe("sent");
+    expect(updatedEmail.finalizedAt).toBe(Number.MAX_SAFE_INTEGER); // Should remain unchanged
+    expect(updatedEmail.complained).toBe(false); // Should remain unchanged
+    expect(updatedEmail.opened).toBe(false); // Should remain unchanged
+  });
+
+  it("does not update email for clicked event", async () => {
+    expect(email.status).toBe("sent");
+    event = createTestEventOfType("email.clicked");
+
+    await exec();
+
+    const updatedEmail = await getEmail();
+    expect(updatedEmail.status).toBe("sent");
+    expect(updatedEmail.finalizedAt).toBe(Number.MAX_SAFE_INTEGER); // Should remain unchanged
+    expect(updatedEmail.complained).toBe(false); // Should remain unchanged
+    expect(updatedEmail.opened).toBe(false); // Should remain unchanged
+  });
+
+  it("does not update email for failed event", async () => {
+    expect(email.status).toBe("sent");
+    event = createTestEventOfType("email.failed");
+
+    await exec();
+
+    const updatedEmail = await getEmail();
+    expect(updatedEmail.status).toBe("sent");
+    expect(updatedEmail.finalizedAt).toBe(Number.MAX_SAFE_INTEGER); // Should remain unchanged
+    expect(updatedEmail.complained).toBe(false); // Should remain unchanged
+    expect(updatedEmail.opened).toBe(false); // Should remain unchanged
+  });
+
+  it("gracefully handles invalid event structure - missing type", async () => {
+    const invalidEvent = {
+      created_at: "2024-01-01T00:00:00Z",
+      data: {
+        email_id: "test-resend-id-123",
+        from: "test@example.com",
+        to: "recipient@example.com",
+        subject: "Test Email",
+      },
+    };
+
+    // Should not throw an error
+    await exec(invalidEvent);
+
+    // Email should remain unchanged
+    const updatedEmail = await getEmail();
+    expect(updatedEmail.status).toBe("sent");
+    expect(updatedEmail.finalizedAt).toBe(Number.MAX_SAFE_INTEGER);
+    expect(updatedEmail.complained).toBe(false);
+    expect(updatedEmail.opened).toBe(false);
+  });
+
+  it("gracefully handles invalid event structure - missing data", async () => {
+    const invalidEvent = {
+      type: "email.delivered",
+      created_at: "2024-01-01T00:00:00Z",
+    };
+
+    // Should not throw an error
+    await exec(invalidEvent);
+
+    // Email should remain unchanged
+    const updatedEmail = await getEmail();
+    expect(updatedEmail.status).toBe("sent");
+    expect(updatedEmail.finalizedAt).toBe(Number.MAX_SAFE_INTEGER);
+    expect(updatedEmail.complained).toBe(false);
+    expect(updatedEmail.opened).toBe(false);
+  });
+
+  it("gracefully handles completely invalid event", async () => {
+    const invalidEvent = "not an object";
+
+    // Should not throw an error
+    await exec(invalidEvent);
+
+    // Email should remain unchanged
+    const updatedEmail = await getEmail();
+    expect(updatedEmail.status).toBe("sent");
+    expect(updatedEmail.finalizedAt).toBe(Number.MAX_SAFE_INTEGER);
+    expect(updatedEmail.complained).toBe(false);
+    expect(updatedEmail.opened).toBe(false);
+  });
+
+  it("gracefully handles null event", async () => {
+    // Should not throw an error
+    await exec(null);
+
+    // Email should remain unchanged
+    const updatedEmail = await getEmail();
+    expect(updatedEmail.status).toBe("sent");
+    expect(updatedEmail.finalizedAt).toBe(Number.MAX_SAFE_INTEGER);
+    expect(updatedEmail.complained).toBe(false);
+    expect(updatedEmail.opened).toBe(false);
+  });
+
+  it("gracefully handles empty object event", async () => {
+    const invalidEvent = {};
+
+    // Should not throw an error
+    await exec(invalidEvent);
+
+    // Email should remain unchanged
+    const updatedEmail = await getEmail();
+    expect(updatedEmail.status).toBe("sent");
+    expect(updatedEmail.finalizedAt).toBe(Number.MAX_SAFE_INTEGER);
+    expect(updatedEmail.complained).toBe(false);
+    expect(updatedEmail.opened).toBe(false);
   });
 });

--- a/src/component/lib.test.ts
+++ b/src/component/lib.test.ts
@@ -25,7 +25,7 @@ describe("handleEmailEvent", () => {
   const exec = (_event = event) =>
     t.mutation(api.lib.handleEmailEvent, { event: _event });
 
-  it("works", async () => {
+  it("updates email for delivered event", async () => {
     await exec();
 
     const updatedEmail = await t.run(async (ctx) => ctx.db.get(sentEmailId));

--- a/src/component/lib.test.ts
+++ b/src/component/lib.test.ts
@@ -1,8 +1,37 @@
-import { convexTest } from "convex-test";
-import { test } from "vitest";
-import schema from "./schema.js";
-import { modules } from "./setup.test.js";
+import { expect, describe, it, beforeEach } from "vitest";
+import { api } from "./_generated/api.js";
+import type { EmailEvent } from "./shared.js";
+import {
+  createTestDeliveredEvent,
+  insertTestSentEmail,
+  setupTest,
+  setupTestLastOptions,
+  type Tester,
+} from "./setup.test.js";
+import { type Id } from "./_generated/dataModel.js";
 
-test("test", async () => {
-  convexTest(schema, modules);
+describe("handleEmailEvent", () => {
+  let t: Tester;
+  let event: EmailEvent;
+  let sentEmailId: Id<"emails">;
+
+  beforeEach(async () => {
+    t = setupTest();
+    event = createTestDeliveredEvent();
+    await setupTestLastOptions(t);
+    sentEmailId = await insertTestSentEmail(t);
+  });
+
+  const exec = (_event = event) =>
+    t.mutation(api.lib.handleEmailEvent, { event: _event });
+
+  it("works", async () => {
+    await exec();
+
+    const updatedEmail = await t.run(async (ctx) => ctx.db.get(sentEmailId));
+    expect(updatedEmail).toBeTruthy();
+    expect(updatedEmail?.status).toBe("delivered");
+    expect(updatedEmail?.finalizedAt).toBeLessThan(Number.MAX_SAFE_INTEGER);
+    expect(updatedEmail?.finalizedAt).toBeGreaterThan(Date.now() - 10000); // Within last 10 seconds
+  });
 });

--- a/src/component/lib.ts
+++ b/src/component/lib.ts
@@ -629,10 +629,12 @@ export const handleEmailEvent = mutation({
     // Event can be anything, so we need to parse it.
     // this will also strip out anything that shouldnt be there.
     const result = attemptToParse(vEmailEvent, args.event);
-    if (result.kind === "error")
-      return console.warn(
+    if (result.kind === "error") {
+      console.warn(
         `Invalid email event received. You might want to to exclude this event from your Resend webhook settings in the Resend dashboard. ${result.error}.`
       );
+      return;
+    }
 
     const event = result.data;
 
@@ -641,10 +643,12 @@ export const handleEmailEvent = mutation({
       .withIndex("by_resendId", (q) => q.eq("resendId", event.data.email_id))
       .unique();
 
-    if (!email)
-      return console.info(
+    if (!email) {
+      console.info(
         `Email not found for resendId: ${event.data.email_id}, ignoring...`
       );
+      return;
+    }
 
     // Returns the changed email or null if not changed
     const changed = iife((): Doc<"emails"> | null => {

--- a/src/component/lib.ts
+++ b/src/component/lib.ts
@@ -641,6 +641,7 @@ export const handleEmailEvent = mutation({
         `Email not found for resendId: ${event.data.email_id}, ignoring...`
       );
 
+    // Returns the changed email or null if not changed
     const changed = iife((): Doc<"emails"> | null => {
       // NOOP -- we do this automatically when we send the email.
       if (event.type == "email.sent") return null;

--- a/src/component/lib.ts
+++ b/src/component/lib.ts
@@ -24,6 +24,7 @@ import { isDeepEqual } from "remeda";
 import schema from "./schema.js";
 import { omit } from "convex-helpers";
 import { parse } from "convex-helpers/validators";
+import { assertExhaustive, iife } from "./utils.js";
 
 // Move some of these to options? TODO
 const SEGMENT_MS = 125;
@@ -625,57 +626,80 @@ export const handleEmailEvent = mutation({
   },
   returns: v.null(),
   handler: async (ctx, args) => {
-    const event = args.event as EmailEvent;
-    const resendId = event.data.email_id;
+    // Event can be anything, so we need to parse it.
+    // this will also strip out anything that shouldnt be there.
+    const event = attemptToParseEvent(args.event);
+    if (typeof event === "string") return console.warn(event);
+
     const email = await ctx.db
       .query("emails")
-      .withIndex("by_resendId", (q) => q.eq("resendId", resendId))
+      .withIndex("by_resendId", (q) => q.eq("resendId", event.data.email_id))
       .unique();
 
-    if (!email) {
-      console.info(`Email not found for resendId: ${resendId}, ignoring...`);
-      return;
-    }
+    if (!email)
+      return console.info(
+        `Email not found for resendId: ${event.data.email_id}, ignoring...`
+      );
 
-    let changed = true;
-    switch (event.type) {
-      case "email.sent":
-        // NOOP -- we do this automatically when we send the email.
-        changed = false;
-        break;
-      case "email.delivered":
-        email.status = "delivered";
-        email.finalizedAt = Date.now();
-        break;
-      case "email.bounced":
-        email.status = "bounced";
-        email.finalizedAt = Date.now();
-        email.errorMessage = event.data.bounce?.message;
-        break;
-      case "email.delivery_delayed":
-        email.status = "delivery_delayed";
-        break;
-      case "email.complained":
-        email.complained = true;
-        break;
-      case "email.opened":
-        email.opened = true;
-        break;
-      case "email.clicked":
-        changed = false;
-        // One email can have multiple clicks, so we don't track them for now.
-        break;
-      default:
-        // Ignore other events
-        return;
-    }
+    const changed = iife((): Doc<"emails"> | null => {
+      // NOOP -- we do this automatically when we send the email.
+      if (event.type == "email.sent") return null;
 
-    if (changed) {
-      await ctx.db.replace(email._id, email);
-    }
-    await enqueueCallbackIfExists(ctx, email, parse(vEmailEvent, event));
+      // These we dont do anything with
+      if (event.type == "email.clicked") return null;
+      if (event.type == "email.failed") return null;
+
+      if (event.type == "email.delivered")
+        return {
+          ...email,
+          status: "delivered",
+          finalizedAt: Date.now(),
+        };
+
+      if (event.type == "email.bounced")
+        return {
+          ...email,
+          status: "bounced",
+          finalizedAt: Date.now(),
+          errorMessage: event.data.bounce?.message,
+        };
+
+      if (event.type == "email.delivery_delayed")
+        return {
+          ...email,
+          status: "delivery_delayed",
+        };
+
+      if (event.type == "email.complained")
+        return {
+          ...email,
+          complained: true,
+        };
+
+      if (event.type == "email.opened")
+        return {
+          ...email,
+          opened: true,
+        };
+
+      assertExhaustive(event);
+
+      return null;
+    });
+
+    if (changed) await ctx.db.replace(email._id, changed);
+
+    await enqueueCallbackIfExists(ctx, changed ?? email, event);
   },
 });
+
+const attemptToParseEvent = (event: unknown): EmailEvent | string => {
+  try {
+    return parse(vEmailEvent, event);
+  } catch (error) {
+    return `Invalid email event received: ${error instanceof Error ? error.message : String(error)}`;
+  }
+};
 
 async function enqueueCallbackIfExists(
   ctx: MutationCtx,

--- a/src/component/lib.ts
+++ b/src/component/lib.ts
@@ -631,10 +631,12 @@ export const handleEmailEvent = mutation({
       .query("emails")
       .withIndex("by_resendId", (q) => q.eq("resendId", resendId))
       .unique();
+
     if (!email) {
       console.info(`Email not found for resendId: ${resendId}, ignoring...`);
       return;
     }
+
     let changed = true;
     switch (event.type) {
       case "email.sent":

--- a/src/component/setup.test.ts
+++ b/src/component/setup.test.ts
@@ -8,6 +8,7 @@ import type {
 import { convexTest } from "convex-test";
 import schema from "./schema.js";
 import type { Doc } from "./_generated/dataModel.js";
+import { assertExhaustive } from "./utils.js";
 
 export const modules = import.meta.glob("./**/*.*s");
 
@@ -19,11 +20,6 @@ export const setupTest = () => {
 export type Tester = ReturnType<typeof setupTest>;
 
 test("setup", () => {});
-
-// Exhaustive helper function to ensure all event types are handled
-const assertExhaustive = (value: never): never => {
-  throw new Error(`Unhandled event type: ${value as string}`);
-};
 
 /**
  * Creates test events for any given email event type with optional overrides.
@@ -79,8 +75,12 @@ export const createTestEventOfType = <T extends EventEventTypes>(
   };
 
   // Helper to merge overrides with base event
-  const applyOverrides = (event: EventEventOfType<T>): EventEventOfType<T> => {
-    if (!overrides) return event;
+  const applyOverrides = (event: {
+    type: string;
+    created_at: string;
+    data: Record<string, unknown>;
+  }): EventEventOfType<T> => {
+    if (!overrides) return event as EventEventOfType<T>;
 
     return {
       ...event,
@@ -94,28 +94,28 @@ export const createTestEventOfType = <T extends EventEventTypes>(
       ...baseEvent,
       type: "email.sent",
       data: baseData,
-    } as EventEventOfType<T>);
+    });
 
   if (type === "email.delivered")
     return applyOverrides({
       ...baseEvent,
       type: "email.delivered",
       data: baseData,
-    } as EventEventOfType<T>);
+    });
 
   if (type === "email.delivery_delayed")
     return applyOverrides({
       ...baseEvent,
       type: "email.delivery_delayed",
       data: baseData,
-    } as EventEventOfType<T>);
+    });
 
   if (type === "email.complained")
     return applyOverrides({
       ...baseEvent,
       type: "email.complained",
       data: baseData,
-    } as EventEventOfType<T>);
+    });
 
   if (type === "email.bounced")
     return applyOverrides({
@@ -129,7 +129,7 @@ export const createTestEventOfType = <T extends EventEventTypes>(
           type: "hard",
         },
       },
-    } as EventEventOfType<T>);
+    });
 
   if (type === "email.opened")
     return applyOverrides({
@@ -144,7 +144,7 @@ export const createTestEventOfType = <T extends EventEventTypes>(
             "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
         },
       },
-    } as EventEventOfType<T>);
+    });
 
   if (type === "email.clicked")
     return applyOverrides({
@@ -160,7 +160,7 @@ export const createTestEventOfType = <T extends EventEventTypes>(
             "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
         },
       },
-    } as EventEventOfType<T>);
+    });
 
   if (type === "email.failed")
     return applyOverrides({
@@ -172,24 +172,11 @@ export const createTestEventOfType = <T extends EventEventTypes>(
           reason: "SMTP server rejected the email",
         },
       },
-    } as EventEventOfType<T>);
+    });
 
   // This ensures exhaustive checking at compile time
   return assertExhaustive(type);
 };
-
-export const createTestDeliveredEvent =
-  (): EventEventOfType<"email.delivered"> => ({
-    type: "email.delivered",
-    created_at: "2024-01-01T00:00:00Z",
-    data: {
-      email_id: "test-resend-id-123",
-      created_at: "2024-01-01T00:00:00Z", // Required in commonFields
-      from: "test@example.com",
-      to: "recipient@example.com",
-      subject: "Test Email",
-    },
-  });
 
 export const createTestRuntimeConfig = (): RuntimeConfig => ({
   apiKey: "test-api-key",

--- a/src/component/setup.test.ts
+++ b/src/component/setup.test.ts
@@ -1,6 +1,73 @@
 /// <reference types="vite/client" />
 import { test } from "vitest";
+import type { EmailEvent, EventEventOfType, RuntimeConfig } from "./shared.js";
+import { convexTest } from "convex-test";
+import schema from "./schema.js";
+import type { Doc } from "./_generated/dataModel.js";
 
 export const modules = import.meta.glob("./**/*.*s");
 
+export const setupTest = () => {
+  const t = convexTest(schema, modules);
+  return t;
+};
+
+export type Tester = ReturnType<typeof setupTest>;
+
 test("setup", () => {});
+
+export const createTestDeliveredEvent =
+  (): EventEventOfType<"email.delivered"> => ({
+    type: "email.delivered",
+    created_at: "2024-01-01T00:00:00Z",
+    data: {
+      email_id: "test-resend-id-123",
+      created_at: "2024-01-01T00:00:00Z", // Required in commonFields
+      from: "test@example.com",
+      to: "recipient@example.com",
+      subject: "Test Email",
+    },
+  });
+
+export const createTestRuntimeConfig = (): RuntimeConfig => ({
+  apiKey: "test-api-key",
+  testMode: true,
+  initialBackoffMs: 1000,
+  retryAttempts: 3,
+});
+
+export const setupTestLastOptions = (
+  t: Tester,
+  overrides?: Partial<Doc<"lastOptions">>
+) =>
+  t.run(async (ctx) => {
+    await ctx.db.insert("lastOptions", {
+      options: {
+        ...createTestRuntimeConfig(),
+      },
+      ...overrides,
+    });
+  });
+
+export const insertTestEmail = (
+  t: Tester,
+  overrides: Omit<Doc<"emails">, "_id" | "_creationTime">
+) => t.run((ctx) => ctx.db.insert("emails", overrides));
+
+export const insertTestSentEmail = (
+  t: Tester,
+  overrides?: Partial<Doc<"emails">>
+) =>
+  insertTestEmail(t, {
+    from: "test@example.com",
+    to: "recipient@example.com",
+    subject: "Test Email",
+    replyTo: [],
+    status: "sent",
+    complained: false,
+    opened: false,
+    resendId: "test-resend-id-123",
+    segment: 1,
+    finalizedAt: Number.MAX_SAFE_INTEGER, // FINALIZED_EPOCH
+    ...overrides,
+  });

--- a/src/component/setup.test.ts
+++ b/src/component/setup.test.ts
@@ -1,6 +1,11 @@
 /// <reference types="vite/client" />
 import { test } from "vitest";
-import type { EmailEvent, EventEventOfType, RuntimeConfig } from "./shared.js";
+import type {
+  EmailEvent,
+  EventEventOfType,
+  EventEventTypes,
+  RuntimeConfig,
+} from "./shared.js";
 import { convexTest } from "convex-test";
 import schema from "./schema.js";
 import type { Doc } from "./_generated/dataModel.js";
@@ -15,6 +20,10 @@ export const setupTest = () => {
 export type Tester = ReturnType<typeof setupTest>;
 
 test("setup", () => {});
+
+export const createTestEventOfType = <
+  T extends EventEventTypes,
+>(): EventEventOfType<T> => {};
 
 export const createTestDeliveredEvent =
   (): EventEventOfType<"email.delivered"> => ({
@@ -52,7 +61,13 @@ export const setupTestLastOptions = (
 export const insertTestEmail = (
   t: Tester,
   overrides: Omit<Doc<"emails">, "_id" | "_creationTime">
-) => t.run((ctx) => ctx.db.insert("emails", overrides));
+) =>
+  t.run(async (ctx) => {
+    const id = await ctx.db.insert("emails", overrides);
+    const email = await ctx.db.get(id);
+    if (!email) throw new Error("Email not found");
+    return email;
+  });
 
 export const insertTestSentEmail = (
   t: Tester,

--- a/src/component/setup.test.ts
+++ b/src/component/setup.test.ts
@@ -21,33 +21,6 @@ export type Tester = ReturnType<typeof setupTest>;
 
 test("setup", () => {});
 
-/**
- * Creates test events for any given email event type with optional overrides.
- *
- * @example
- * // Basic usage with defaults
- * const sentEvent = createTestEventOfType("email.sent");
- *
- * @example
- * // Override top-level properties
- * const customEvent = createTestEventOfType("email.delivered", {
- *   created_at: "2024-12-01T00:00:00Z"
- * });
- *
- * @example
- * // Override data properties
- * const customDataEvent = createTestEventOfType("email.bounced", {
- *   data: {
- *     from: "custom@sender.com",
- *     bounce: {
- *       message: "Custom bounce message",
- *       subType: "recipient-issue",
- *       type: "soft"
- *     }
- *   }
- * });
- */
-
 export const createTestEventOfType = <T extends EventEventTypes>(
   type: T,
   overrides?: Partial<EventEventOfType<T>>
@@ -174,7 +147,6 @@ export const createTestEventOfType = <T extends EventEventTypes>(
       },
     });
 
-  // This ensures exhaustive checking at compile time
   return assertExhaustive(type);
 };
 

--- a/src/component/shared.ts
+++ b/src/component/shared.ts
@@ -134,7 +134,8 @@ export const vEmailEvent = v.union(
 );
 
 export type EmailEvent = Infer<typeof vEmailEvent>;
-export type EventEventOfType<T extends EmailEvent["type"]> = Extract<
+export type EventEventTypes = EmailEvent["type"];
+export type EventEventOfType<T extends EventEventTypes> = Extract<
   EmailEvent,
   { type: T }
 >;

--- a/src/component/shared.ts
+++ b/src/component/shared.ts
@@ -134,6 +134,10 @@ export const vEmailEvent = v.union(
 );
 
 export type EmailEvent = Infer<typeof vEmailEvent>;
+export type EventEventOfType<T extends EmailEvent["type"]> = Extract<
+  EmailEvent,
+  { type: T }
+>;
 
 /* Type utils follow */
 

--- a/src/component/utils.ts
+++ b/src/component/utils.ts
@@ -1,5 +1,29 @@
+import { parse } from "convex-helpers/validators";
+import type { Validator, Infer } from "convex/values";
+
 export const assertExhaustive = (value: never): never => {
   throw new Error(`Unhandled event type: ${value as string}`);
 };
 
 export const iife = <T>(fn: () => T): T => fn();
+
+/**
+ * Generic function to attempt parsing with proper TypeScript type narrowing
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function attemptToParse<T extends Validator<any, any, any>>(
+  validator: T,
+  value: unknown
+): { kind: "success"; data: Infer<T> } | { kind: "error"; error: unknown } {
+  try {
+    return {
+      kind: "success",
+      data: parse(validator, value),
+    };
+  } catch (error) {
+    return {
+      kind: "error",
+      error,
+    };
+  }
+}

--- a/src/component/utils.ts
+++ b/src/component/utils.ts
@@ -1,0 +1,5 @@
+export const assertExhaustive = (value: never): never => {
+  throw new Error(`Unhandled event type: ${value as string}`);
+};
+
+export const iife = <T>(fn: () => T): T => fn();


### PR DESCRIPTION
This PR fixes an issue that was raised by a user on discord: https://discord.com/channels/1019350475847499849/1401189654748729364/1401189654748729364

> 8/2/2025, 6:32:48 PM [CONVEX M(lib:handleEmailEvent)] Uncaught Error: unique() query returned more than one result from table emails:
>  [j57chbeghegwtj8yedvha2xgzn7mxp76, j57f4d10sj6g3kjzn9kk5sb88d7mw76d, ...]
>     at async handler (../node_modules/@convex-dev/resend/src/component/lib.ts:633:16)
> 
>  ✓ Compiled in 36ms
> 8/2/2025, 6:32:48 PM [CONVEX H(POST /resend-webhook)] Uncaught Error: Uncaught Error: unique() query returned more than one result from table emails:
>  [j57chbeghegwtj8yedvha2xgzn7mxp76, j57f4d10sj6g3kjzn9kk5sb88d7mw76d, ...]
>     at async handler (../node_modules/@convex-dev/resend/src/component/lib.ts:633:16)
> 
>     at async handleResendEventWebhook [as handleResendEventWebhook] (../../node_modules/@convex-dev/resend/src/client/index.ts:360:6)
>     at async <anonymous> (../convex/http.ts:12:1)
>     at async invokeFunction (../../node_modules/convex/src/server/impl/registration_impl.ts:80:2)
>     at async invokeHttpAction (../../node_modules/convex/src/server/impl/registration_impl.ts:453:0)
>     at async <anonymous> (../../node_modules/convex/src/server/router.ts:322:16)
> 
> 
> 
> Dont know how can i share my db data but here is instance name "proficient-stork-122"
> 
> Root Cause : So if the mail fails the resend ID is unset then the unique query is failing

So the issue is that `handleEmailEvent` takes in an `event` typed to `any` but then trusts that it is a valid `EmailEvent`. This might not be the case if the user chooses to send events other than Email events to us. 

To fix this I pulled up the parse higher in the `handleEmailEvent` so that it now attempts the parse early and bombs out if it not the shape we are expecting. Before it exits it leaves the user with a nice warning in their logs to let them know they might want to exclude that event from being sent in the Resend dashboard.

While I was here I decided to tidy up the function and implemented a bunch of tests around it to make sure there are not other issues in this function.