### PR TITLE
allow simple labels in test email addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ Then, calling `sendTestEmail` from anywhere in your app will send this test emai
 If you want to send emails to real addresses, you need to disable `testMode`.
 You can do this in `ResendOptions`, [as detailed below](#resend-component-options-and-going-into-production).
 
+A note on test email addresses:
+[Resend allows the use of labels](https://resend.com/docs/dashboard/emails/send-test-emails#using-labels-effectively) for test emails. 
+For simplicity, this component only allows labels matching `[a-z0-9_-]*`, e.g. `delivered+user-1@resend.dev`.
+
 ## Advanced Usage
 
 ### Setting up a Resend webhook

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ You can do this in `ResendOptions`, [as detailed below](#resend-component-option
 
 A note on test email addresses:
 [Resend allows the use of labels](https://resend.com/docs/dashboard/emails/send-test-emails#using-labels-effectively) for test emails. 
-For simplicity, this component only allows labels matching `[a-z0-9_-]*`, e.g. `delivered+user-1@resend.dev`.
+For simplicity, this component only allows labels matching `[a-zA-Z0-9_-]*`, e.g. `delivered+user-1@resend.dev`.
 
 ## Advanced Usage
 

--- a/src/component/lib.ts
+++ b/src/component/lib.ts
@@ -24,7 +24,7 @@ import { isDeepEqual } from "remeda";
 import schema from "./schema.js";
 import { omit } from "convex-helpers";
 import { parse } from "convex-helpers/validators";
-import { assertExhaustive, attemptToParse, iife } from "./utils.js";
+import { assertExhaustive, attemptToParse, iife, isValidResendTestEmail } from "./utils.js";
 
 // Move some of these to options? TODO
 const SEGMENT_MS = 125;
@@ -36,12 +36,6 @@ const RESEND_ONE_CALL_EVERY_MS = 600; // Half the stated limit, but it keeps us 
 const FINALIZED_EMAIL_RETENTION_MS = 1000 * 60 * 60 * 24 * 7; // 7 days
 const FINALIZED_EPOCH = Number.MAX_SAFE_INTEGER;
 const ABANDONED_EMAIL_RETENTION_MS = 1000 * 60 * 60 * 24 * 30; // 30 days
-
-const RESEND_TEST_EMAILS = new Set([
-  "delivered@resend.dev",
-  "bounced@resend.dev",
-  "complained@resend.dev",
-]);
 
 const PERMANENT_ERROR_CODES = new Set([
   400, 401 /* 402 not included - unclear spec */, 403, 404, 405, 406, 407, 408,
@@ -100,7 +94,7 @@ export const sendEmail = mutation({
   returns: v.id("emails"),
   handler: async (ctx, args) => {
     // We only allow test emails in test mode.
-    if (args.options.testMode && !RESEND_TEST_EMAILS.has(args.to)) {
+    if (args.options.testMode && !isValidResendTestEmail(args.to)) {
       throw new Error(
         `Test mode is enabled, but email address is not a valid resend test address. Did you want to set testMode: false in your ResendOptions?`
       );

--- a/src/component/utils.test.ts
+++ b/src/component/utils.test.ts
@@ -15,6 +15,7 @@ describe("isValidResendTestEmail", () => {
     expect(isValidResendTestEmail("bounced+user-pw-reset-test@resend.dev")).toBe(true);
     expect(isValidResendTestEmail("complained+account-reset_test1@resend.dev")).toBe(true);
     expect(isValidResendTestEmail("complained+@resend.dev")).toBe(true);
+    expect(isValidResendTestEmail("complained+COMPLAINED@resend.dev")).toBe(true);
   });
 
   it("rejects invalid test emails with or without labels", () => {

--- a/src/component/utils.test.ts
+++ b/src/component/utils.test.ts
@@ -1,0 +1,32 @@
+import {describe, it, expect} from "vitest";
+import { isValidResendTestEmail } from "./utils.js";
+
+describe("isValidResendTestEmail", () => {
+
+  it("allows valid test emails without labels", () => {
+    expect(isValidResendTestEmail("delivered@resend.dev")).toBe(true);
+    expect(isValidResendTestEmail("bounced@resend.dev")).toBe(true);
+    expect(isValidResendTestEmail("complained@resend.dev")).toBe(true);
+  });
+
+  it("allows valid test emails with labels", () => {
+    expect(isValidResendTestEmail("delivered+user-1@resend.dev")).toBe(true);
+    expect(isValidResendTestEmail("delivered+foo-bar@resend.dev")).toBe(true);
+    expect(isValidResendTestEmail("bounced+user-pw-reset-test@resend.dev")).toBe(true);
+    expect(isValidResendTestEmail("complained+account-reset_test1@resend.dev")).toBe(true);
+    expect(isValidResendTestEmail("complained+@resend.dev")).toBe(true);
+  });
+
+  it("rejects invalid test emails with or without labels", () => {
+    expect(isValidResendTestEmail("foobar@resend.dev")).toBe(false);
+    expect(isValidResendTestEmail("bazfoo+user@resend.dev")).toBe(false);
+    expect(isValidResendTestEmail("delivered@resended.dev")).toBe(false);
+  });
+
+  it("rejects test emails with disallowed special characters in the label", () => {
+    expect(isValidResendTestEmail("delivered+foo.bar@resend.dev")).toBe(false);
+    expect(isValidResendTestEmail("bounced+user/1@resend.dev")).toBe(false);
+    expect(isValidResendTestEmail("bounced+user$1@resend.dev")).toBe(false);
+  });
+
+});

--- a/src/component/utils.ts
+++ b/src/component/utils.ts
@@ -34,7 +34,7 @@ export function attemptToParse<T extends Validator<any, any, any>>(
  * only says "any string": https://resend.com/docs/dashboard/emails/send-test-emails#using-labels-effectively
  * and a full RFC-5322 compliant regex would be way too long.
  */
-const RESEND_TEST_EMAIL_REGEXT = /^(delivered|bounced|complained)(\+[a-z0-9_-]*)?@resend\.dev$/;
+const RESEND_TEST_EMAIL_REGEXT = /^(delivered|bounced|complained)(\+[a-zA-Z0-9_-]*)?@resend\.dev$/;
 
 /**
  * Check if the given e-mail address is a valid test e-mail for Resend.

--- a/src/component/utils.ts
+++ b/src/component/utils.ts
@@ -27,3 +27,19 @@ export function attemptToParse<T extends Validator<any, any, any>>(
     };
   }
 }
+
+/**
+ * This is one is intentionally kept simple and only allows - and _ as special characters
+ * since Resend does not specify what pattern a label must follow, the documentation
+ * only says "any string": https://resend.com/docs/dashboard/emails/send-test-emails#using-labels-effectively
+ * and a full RFC-5322 compliant regex would be way too long.
+ */
+const RESEND_TEST_EMAIL_REGEXT = /^(delivered|bounced|complained)(\+[a-z0-9_-]*)?@resend\.dev$/;
+
+/**
+ * Check if the given e-mail address is a valid test e-mail for Resend.
+ * @param email
+ */
+export function isValidResendTestEmail(email: string): boolean {
+  return RESEND_TEST_EMAIL_REGEXT.test(email);
+}


### PR DESCRIPTION
This PR addresses #36:
- allow [test email addresses with labels](https://resend.com/docs/dashboard/emails/send-test-emails#using-labels-effectively) in test mode
- adds tests for validating test email addresses
- adds a note to the README on the restrictions (described below)

The regex currently on allows `[a-zA-Z0-9_-]*` for the labels since Resend itself does not state what is allowed or not and going [full RFC-5322 compliant](https://stackoverflow.com/a/201378) seems overkill, especially since there are positional limitations for special characters:
- `delivered+.foo@resend.dev` works
- `delivered+.foo.@resend.dev` does not (422 error) because the local-part of an email cannot end with `.`

<details><summary>Some tests I did with the API</summary>
<p>

<img width="531" height="734" alt="image" src="https://github.com/user-attachments/assets/424d9bfa-079f-4ba7-970c-c7544c086106" />


</p>
</details> 

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
