### PR TITLE
adds template object to resend batch call

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -147,6 +147,8 @@ export type SendEmailOptions = {
   subject: string;
   html?: string;
   text?: string;
+  template?: string;
+  variables?: Record<string, string>;
   replyTo?: string[];
   headers?: { name: string; value: string }[];
 };
@@ -271,7 +273,7 @@ export class Resend {
 
   async sendEmailManually(
     ctx: RunMutationCtx,
-    options: Omit<SendEmailOptions, "html" | "text">,
+    options: Omit<SendEmailOptions, "html" | "text" | "template" | "variables">,
     sendCallback: (emailId: EmailId) => Promise<string>,
   ): Promise<EmailId> {
     const emailId = (await ctx.runMutation(
@@ -367,6 +369,8 @@ export class Resend {
     createdAt: number;
     html?: string;
     text?: string;
+    template?: string;
+    variables?: Record<string, string>;
   } | null> {
     return await ctx.runQuery(this.component.lib.get, {
       emailId,

--- a/src/component/lib.ts
+++ b/src/component/lib.ts
@@ -87,6 +87,8 @@ export const sendEmail = mutation({
     html: v.optional(v.string()),
     text: v.optional(v.string()),
     replyTo: v.optional(v.array(v.string())),
+    template: v.optional(v.string()),
+    variables: v.optional(v.record(v.string(), v.string())),
     headers: v.optional(
       v.array(
         v.object({
@@ -106,8 +108,8 @@ export const sendEmail = mutation({
     }
 
     // We require either html or text to be provided. No body = no bueno.
-    if (args.html === undefined && args.text === undefined) {
-      throw new Error("Either html or text must be provided");
+    if (args.html === undefined && args.text === undefined && args.template === undefined) {
+      throw new Error("Either html, text, or template must be provided");
     }
 
     // Store the text/html into separate records to keep things fast and memory low when we work with email batches.
@@ -140,6 +142,8 @@ export const sendEmail = mutation({
       html: htmlContentId,
       text: textContentId,
       headers: args.headers,
+      template: args.template,
+      variables: args.variables,
       segment,
       status: "waiting",
       complained: false,
@@ -607,6 +611,10 @@ async function createResendBatchPayload(
           ]),
         )
       : undefined,
+    template: email.template ? { 
+      id: email.template,
+      variables: email.variables,
+    } : undefined,
   }));
 
   return [emails.map((e) => e._id), JSON.stringify(batchPayload)];

--- a/src/component/schema.ts
+++ b/src/component/schema.ts
@@ -22,6 +22,8 @@ export default defineSchema({
     replyTo: v.array(v.string()),
     html: v.optional(v.id("content")),
     text: v.optional(v.id("content")),
+    template: v.optional(v.string()),
+    variables: v.optional(v.record(v.string(), v.string())),
     headers: v.optional(
       v.array(
         v.object({


### PR DESCRIPTION
<!-- Describe your PR here. -->

Closes #44 

Per [Resend's /batch doc](https://resend.com/docs/api-reference/emails/send-batch-emails#param-template), we can pass the `template` object in order to use templates defined by a user in their Resend dashboard.

This PR is more of a conversation-starter than anything. I assume that there was a (good) reason to omit `template` functionality from this component, but in making these changes I couldn't infer what that (good) reason was :)

Please let me know if a) this feature is useful, b) I'm misunderstanding the concept, or c) there's a reason `template`s shouldn't be implemented at all.

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
