### PR TITLE
fix type mismatch in thick client

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -419,12 +419,12 @@ export class Resend {
     headers?: { name: string; value: string }[];
     status: Status;
     errorMessage?: string;
-    bounced: boolean;
+    bounced?: boolean;
     complained: boolean;
-    failed: boolean;
-    deliveryDelayed: boolean;
-    opened: boolean;
-    clicked: boolean;
+    failed?: boolean;
+    deliveryDelayed?: boolean;
+    opened?: boolean;
+    clicked?: boolean;
     resendId?: string;
     finalizedAt: number;
     createdAt: number;

--- a/src/component/_generated/component.ts
+++ b/src/component/_generated/component.ts
@@ -64,14 +64,14 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         { emailId: string },
         {
           bcc?: Array<string>;
-          bounced: boolean;
+          bounced?: boolean;
           cc?: Array<string>;
-          clicked: boolean;
+          clicked?: boolean;
           complained: boolean;
           createdAt: number;
-          deliveryDelayed: boolean;
+          deliveryDelayed?: boolean;
           errorMessage?: string;
-          failed: boolean;
+          failed?: boolean;
           finalizedAt: number;
           from: string;
           headers?: Array<{ name: string; value: string }>;


### PR DESCRIPTION
Forgot to update fields to optional in return

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Email status fields are now optional rather than required, allowing more flexible status reporting across bounced, failed, deliveryDelayed, opened, and clicked statuses.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->