### PR TITLE
add configurable rate limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,15 @@ Check out the [docstrings](./src/client/index.ts), but notable options include:
   develop your project, `testMode` is default **true**. You need to explicitly
   set this to `false` for the component to allow you to enqueue emails to
   artibrary addresses.
+- `rateLimitPerSecond`: The rate limit in requests per second for the Resend
+  API. Defaults to 2 requests per second, which is the default Resend rate
+  limit. If your Resend account has a higher rate limit (e.g., 100 requests per
+  second), set this value accordingly. For example:
+  ```ts
+  export const resend: Resend = new Resend(components.resend, {
+    rateLimitPerSecond: 100,
+  });
+  ```
 - `onEmailEvent`: Your email event callback, as outlined above! Check out the
   [docstrings](./src/client/index.ts) for details on the events that are
   emitted.

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -46,6 +46,7 @@ function getDefaultConfig(): Config {
     initialBackoffMs: 30000,
     retryAttempts: 5,
     testMode: true,
+    rateLimitPerSecond: 2,
   };
 }
 
@@ -94,6 +95,14 @@ export type ResendOptions = {
       event: EmailEvent;
     }
   > | null;
+
+  /**
+   * The rate limit in requests per second for the Resend API.
+   * Defaults to 2 requests per second, which is the default Resend rate limit.
+   * If your Resend account has a higher rate limit (e.g., 100 requests per second),
+   * set this value accordingly.
+   */
+  rateLimitPerSecond?: number;
 };
 
 async function configToRuntimeConfig(
@@ -112,6 +121,7 @@ async function configToRuntimeConfig(
     initialBackoffMs: config.initialBackoffMs,
     retryAttempts: config.retryAttempts,
     testMode: config.testMode,
+    rateLimitPerSecond: config.rateLimitPerSecond,
     onEmailEvent: onEmailEvent
       ? { fnHandle: await createFunctionHandle(onEmailEvent) }
       : undefined,
@@ -225,6 +235,8 @@ export class Resend {
         options?.initialBackoffMs ?? defaultConfig.initialBackoffMs,
       retryAttempts: options?.retryAttempts ?? defaultConfig.retryAttempts,
       testMode: options?.testMode ?? defaultConfig.testMode,
+      rateLimitPerSecond:
+        options?.rateLimitPerSecond ?? defaultConfig.rateLimitPerSecond,
     };
     if (options?.onEmailEvent) {
       this.onEmailEvent = options.onEmailEvent;

--- a/src/component/setup.test.ts
+++ b/src/component/setup.test.ts
@@ -155,6 +155,7 @@ export const createTestRuntimeConfig = (): RuntimeConfig => ({
   testMode: true,
   initialBackoffMs: 1000,
   retryAttempts: 3,
+  rateLimitPerSecond: 2,
 });
 
 export const setupTestLastOptions = (

--- a/src/component/shared.ts
+++ b/src/component/shared.ts
@@ -37,6 +37,7 @@ export const vOptions = v.object({
   retryAttempts: v.number(),
   apiKey: v.string(),
   testMode: v.boolean(),
+  rateLimitPerSecond: v.optional(v.number()),
   onEmailEvent: v.optional(onEmailEvent),
 });
 


### PR DESCRIPTION
Fixes #38 
Allows users to specify if Resend has increased their rate limit.
----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Getting Started guide now includes rate limiting configuration details, examples, and default settings in the Advanced Usage section

* **New Features**
  * Introduced configurable rate limiting to control request throughput. Users can now customize the number of requests per second to optimize performance and ensure compatibility with their application requirements (default: 2 requests per second)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->