### PR TITLE
Fix confusion on manual send using Sdk versus component. Fixes #54

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,16 +307,9 @@ import { internalMutation } from "./_generated/server";
 import { Resend as ResendComponent } from "@convex-dev/resend";
 import { Resend } from "resend";
 
-const resend = new Resend("re_xxxxxxxxx");
+const resendSdk = new Resend("re_xxxxxxxxx");
 
 export const resendResendComponent = new ResendComponent(components.resend, {});
-
-await resend.emails.send({
-  from: "Acme <onboarding@resend.dev>",
-  to: ["delivered@resend.dev"],
-  subject: "hello world",
-  html: "<p>it works!</p>",
-});
 
 export const sendManualEmail = internalMutation({
   args: {},
@@ -330,7 +323,7 @@ export const sendManualEmail = internalMutation({
       ctx,
       { from, to, subject },
       async (emailId) => {
-        const data = await resend.emails.send({
+        const data = await resendSdk.emails.send({
           from,
           to,
           subject,


### PR DESCRIPTION
The docs showed how to use the Resend Component alongside the resendSDK. The naming confusion led to an incorrect example. This fixes the example. Thanks to @carlos-vitallink360 for calling it out.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated email service integration examples in the documentation to reflect internal naming changes.

* **Chores**
  * Code reorganization for improved internal consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->