### PR TITLE
chore(deps): update @convex-dev/workpool to ^0.4.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@convex-dev/rate-limiter": "^0.3.0",
-        "@convex-dev/workpool": "^0.3.0",
+        "@convex-dev/workpool": "^0.4.6",
         "remeda": "^2.26.0",
         "resend": "^6.6.0",
         "svix": "^1.70.0"
@@ -39,7 +39,7 @@
         "vitest": "4.0.18"
       },
       "peerDependencies": {
-        "convex": "^1.24.8",
+        "convex": "^1.31.7",
         "convex-helpers": "^0.1.106"
       }
     },
@@ -572,12 +572,12 @@
       }
     },
     "node_modules/@convex-dev/workpool": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@convex-dev/workpool/-/workpool-0.3.1.tgz",
-      "integrity": "sha512-uw4Mi+irhhoYA/KwaMo5wXyYJ7BbxqeaLcCZbst3t1SxPN5488rpnR0OwBcPDCmwcdQjBVHOx+q8S4GUjq0Csg==",
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@convex-dev/workpool/-/workpool-0.4.6.tgz",
+      "integrity": "sha512-e+cIgQePx5rrGizvzaYocWQCsDFbFlYqR1ZbtFPLa909izwc5GvoasPJPANeFhHRWaA5NBipNVqNtfHySi7Ldw==",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "convex": "^1.24.8",
+        "convex": "^1.31.7",
         "convex-helpers": "^0.1.94"
       }
     },

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     }
   },
   "peerDependencies": {
-    "convex": "^1.24.8",
+    "convex": "^1.31.7",
     "convex-helpers": "^0.1.106"
   },
   "devDependencies": {
@@ -88,7 +88,7 @@
   "module": "./dist/client/index.js",
   "dependencies": {
     "@convex-dev/rate-limiter": "^0.3.0",
-    "@convex-dev/workpool": "^0.3.0",
+    "@convex-dev/workpool": "^0.4.6",
     "remeda": "^2.26.0",
     "resend": "^6.6.0",
     "svix": "^1.70.0"


### PR DESCRIPTION
## Summary
Bumps `@convex-dev/workpool` from `^0.3.0` to `^0.4.6`, and aligns the
`convex` peer dependency to `^1.31.7` (the version workpool 0.4.6
itself peers on).
## Why this is safe
The workpool 0.4.0 release stores args & `onComplete.context > 8kb` in a
new `payloads` table. Per its
[CHANGELOG](https://github.com/get-convex/workpool/blob/main/CHANGELOG.md),
**0.3.2 already added the forwards-compatible schema specifically for
this upgrade** — so there is no migration required for users on 0.3.x.
The public `Workpool` API surface used by this component is unchanged:
- `new Workpool(component, { maxParallelism })`
- `enqueueAction(ctx, fn, args, { retry, runAfter, context, onComplete })`
- `enqueueMutation(ctx, handle, args)`
- `defineOnComplete({ context, handler })`
No code changes are needed in `src/component/lib.ts` or
`src/component/convex.config.ts`.
The peer of `convex` is bumped to `^1.31.7` because that is what
workpool 0.4.6 requires; otherwise an end-user with `convex@1.24.x ..
1.31.6` would get an unsatisfiable peer.

## Test plan
- [x] `npm run build` ✅
- [x] `npm run test` ✅ (27/27)
- [x] `npm run lint` ✅

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
