### PR TITLE
log permanent Resend API errors to console.error

### DIFF
--- a/src/component/lib.ts
+++ b/src/component/lib.ts
@@ -552,7 +552,15 @@ export const callResendAPIWithBatch = internalAction({
     if (!response.ok) {
       if (PERMANENT_ERROR_CODES.has(response.status)) {
         const errorMessage = `Resend API error: ${response.status} ${response.statusText} ${await response.text()}`;
-        console.error(errorMessage);
+        console.error(
+          JSON.stringify({
+            status: "permanent_failure",
+            httpStatus: response.status,
+            httpStatusText: response.statusText,
+            errorMessage,
+            emailIds: args.emails,
+          })
+        );
         await ctx.runMutation(internal.lib.markEmailsFailed, {
           emailIds: args.emails,
           errorMessage,

--- a/src/component/lib.ts
+++ b/src/component/lib.ts
@@ -551,10 +551,11 @@ export const callResendAPIWithBatch = internalAction({
     });
     if (!response.ok) {
       if (PERMANENT_ERROR_CODES.has(response.status)) {
-        // report the error to the user
+        const errorMessage = `Resend API error: ${response.status} ${response.statusText} ${await response.text()}`;
+        console.error(errorMessage);
         await ctx.runMutation(internal.lib.markEmailsFailed, {
           emailIds: args.emails,
-          errorMessage: `Resend API error: ${response.status} ${response.statusText} ${await response.text()}`,
+          errorMessage,
         });
         return;
       }


### PR DESCRIPTION
## Summary
- When the Resend API returns a permanent error (401, 403, etc.), the action marked the email failed but returned successfully, so the workpool counted it as `succeeded` and nothing showed up in Convex function logs.
- Add a `console.error` before the early return so the failure is visible in the dashboard. The same message is still passed to `markEmailsFailed`.

Fixes #71

## Why not throw and let workpool report failed?

Workpool's success/failure semantics are about retries — "failed" means "the action crashed, retry it." A permanent error like 401 is the opposite: a definitive answer that retrying won't help. Throwing would trigger pointless retries against a key that will never work.

The intended separation:
- **Email status** (`resend.status(ctx, emailId)`) is the per-email source of truth — already correctly marked failed.
- **Workpool stats** are infra-level retry metrics, not a per-email outcome channel.
- **Logs** are where operators discover misconfig like a bad API key — which is what this `console.error` fixes.

A stronger signal for users who don't watch logs would be a proper `onEmailFailed` callback, not abusing workpool retries — out of scope here.

## Test plan
- [ ] Trigger a 401 (e.g. invalid API key) and confirm the error appears in Convex function logs
- [ ] Confirm the email's `errorMessage` field is still populated via `resend.status(...)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)