### PR TITLE
Persist cc and bcc for manual emails

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -340,6 +340,8 @@ export class Resend {
       {
         from: options.from,
         to: options.to,
+        cc: options.cc,
+        bcc: options.bcc,
         subject: options.subject,
         replyTo: options.replyTo,
         headers: options.headers,

--- a/src/component/_generated/component.ts
+++ b/src/component/_generated/component.ts
@@ -49,6 +49,8 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         "mutation",
         "internal",
         {
+          bcc?: Array<string> | string;
+          cc?: Array<string> | string;
           from: string;
           headers?: Array<{ name: string; value: string }>;
           replyTo?: Array<string>;

--- a/src/component/lib.test.ts
+++ b/src/component/lib.test.ts
@@ -380,3 +380,31 @@ describe("sendEmail with templates", () => {
     ).rejects.toThrow("Subject is required when not using a template");
   });
 });
+
+describe("createManualEmail", () => {
+  let t: Tester;
+
+  beforeEach(async () => {
+    t = setupTest();
+  });
+
+  it("persists cc and bcc recipients", async () => {
+    const emailId: Id<"emails"> = await t.mutation(api.lib.createManualEmail, {
+      from: "test@resend.dev",
+      to: "delivered@resend.dev",
+      cc: "cc@resend.dev",
+      bcc: ["bcc@resend.dev"],
+      subject: "Manual email",
+    });
+
+    const email = await t.run(async (ctx) => {
+      const _email = await ctx.db.get("emails", emailId);
+      if (!_email) throw new Error("Email not found");
+      return _email;
+    });
+
+    expect(email.to).toEqual(["delivered@resend.dev"]);
+    expect(email.cc).toEqual(["cc@resend.dev"]);
+    expect(email.bcc).toEqual(["bcc@resend.dev"]);
+  });
+});

--- a/src/component/lib.ts
+++ b/src/component/lib.ts
@@ -222,6 +222,8 @@ export const createManualEmail = mutation({
   args: {
     from: v.string(),
     to: v.union(v.array(v.string()), v.string()),
+    cc: v.optional(v.union(v.array(v.string()), v.string())),
+    bcc: v.optional(v.union(v.array(v.string()), v.string())),
     subject: v.string(),
     replyTo: v.optional(v.array(v.string())),
     headers: v.optional(
@@ -238,6 +240,8 @@ export const createManualEmail = mutation({
     const emailId = await ctx.db.insert("emails", {
       from: args.from,
       to: Array.isArray(args.to) ? args.to : [args.to],
+      cc: toArray(args.cc),
+      bcc: toArray(args.bcc),
       subject: args.subject,
       headers: args.headers,
       segment: Infinity,
@@ -254,6 +258,11 @@ export const createManualEmail = mutation({
     return emailId;
   },
 });
+
+function toArray<T>(value: T | T[] | undefined): T[] | undefined {
+  if (value === undefined) return undefined;
+  return Array.isArray(value) ? value : [value];
+}
 
 export const updateManualEmail = mutation({
   args: {


### PR DESCRIPTION
## Summary
- Forward `cc` and `bcc` from `sendEmailManually` to `createManualEmail`
- Persist manual email cc/bcc recipients on the component email row
- Add regression coverage for manual email recipient metadata

## Verification
- `npm run build`
- `npm run test`
- `npm run lint`
- `npm run typecheck`