### PR TITLE
support ActionCtx in public API methods

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -11,9 +11,10 @@ import { Webhook } from "svix";
 import {
   Template,
   vEmailEvent,
+  type ActionCtx,
   type EmailEvent,
-  type RunMutationCtx,
-  type RunQueryCtx,
+  type MutationCtx,
+  type QueryCtx,
   type RuntimeConfig,
   type Status,
 } from "../component/shared.js";
@@ -246,7 +247,7 @@ export class Resend {
    * @returns The id of the email within the component.
    */
   async sendEmail(
-    ctx: RunMutationCtx,
+    ctx: MutationCtx | ActionCtx,
     options: SendEmailOptions,
   ): Promise<EmailId>;
   /**
@@ -270,7 +271,7 @@ export class Resend {
    * @returns The id of the email within the component.
    */
   async sendEmail(
-    ctx: RunMutationCtx,
+    ctx: MutationCtx | ActionCtx,
     from: string,
     to: string,
     subject: string,
@@ -281,7 +282,7 @@ export class Resend {
   ): Promise<EmailId>;
   /** @deprecated Use the object format e.g. `{ from, to, subject, html }` */
   async sendEmail(
-    ctx: RunMutationCtx,
+    ctx: MutationCtx | ActionCtx,
     fromOrOptions: string | SendEmailOptions,
     to?: string,
     subject?: string,
@@ -323,7 +324,7 @@ export class Resend {
   }
 
   async sendEmailManually(
-    ctx: RunMutationCtx,
+    ctx: MutationCtx | ActionCtx,
     options: {
       from: string;
       to: string | string[];
@@ -381,7 +382,7 @@ export class Resend {
    * either a mutation or an action.
    * @param emailId The id of the email to cancel. This was returned from {@link sendEmail}.
    */
-  async cancelEmail(ctx: RunMutationCtx, emailId: EmailId) {
+  async cancelEmail(ctx: MutationCtx | ActionCtx, emailId: EmailId) {
     await ctx.runMutation(this.component.lib.cancelEmail, {
       emailId,
     });
@@ -396,7 +397,7 @@ export class Resend {
    * @returns {@link EmailStatus} The status of the email.
    */
   async status(
-    ctx: RunQueryCtx,
+    ctx: QueryCtx | MutationCtx | ActionCtx,
     emailId: EmailId,
   ): Promise<EmailStatus | null> {
     return await ctx.runQuery(this.component.lib.getStatus, {
@@ -413,7 +414,7 @@ export class Resend {
    * @returns The email, or null if the email does not exist.
    */
   async get(
-    ctx: RunQueryCtx,
+    ctx: QueryCtx | MutationCtx | ActionCtx,
     emailId: EmailId,
   ): Promise<{
     from: string;
@@ -452,7 +453,7 @@ export class Resend {
    * @returns A response to send back to Resend.
    */
   async handleResendEventWebhook(
-    ctx: RunMutationCtx,
+    ctx: MutationCtx | ActionCtx,
     req: Request,
   ): Promise<Response> {
     if (this.config.webhookSecret === "") {

--- a/src/component/lib.ts
+++ b/src/component/lib.ts
@@ -21,7 +21,7 @@ import {
   vTemplate,
 } from "./shared.js";
 import type { FunctionHandle } from "convex/server";
-import type { EmailEvent, RunMutationCtx, RunQueryCtx } from "./shared.js";
+import type { EmailEvent } from "./shared.js";
 import { isDeepEqual } from "remeda";
 import schema from "./schema.js";
 import { omit } from "convex-helpers";
@@ -365,10 +365,14 @@ export const get = query({
       return null;
     }
     const html = email.html
-      ? new TextDecoder().decode((await ctx.db.get("content", email.html))?.content)
+      ? new TextDecoder().decode(
+          (await ctx.db.get("content", email.html))?.content,
+        )
       : undefined;
     const text = email.text
-      ? new TextDecoder().decode((await ctx.db.get("content", email.text))?.content)
+      ? new TextDecoder().decode(
+          (await ctx.db.get("content", email.text))?.content,
+        )
       : undefined;
     return {
       ...omit(email, ["html", "text", "_id", "_creationTime"]),
@@ -568,7 +572,7 @@ export const callResendAPIWithBatch = internalAction({
             httpStatusText: response.statusText,
             errorMessage,
             emailIds: args.emails,
-          })
+          }),
         );
         await ctx.runMutation(internal.lib.markEmailsFailed, {
           emailIds: args.emails,
@@ -725,7 +729,7 @@ async function createResendBatchPayload(
 }
 
 const FIXED_WINDOW_DELAY = 100;
-async function getDelay(ctx: RunMutationCtx & RunQueryCtx): Promise<number> {
+async function getDelay(ctx: MutationCtx): Promise<number> {
   const limit = await resendApiRateLimiter.limit(ctx, "resendApi", {
     reserve: true,
   });
@@ -760,7 +764,9 @@ export const getAllContentByIds = internalQuery({
 export const getEmailsByIds = internalQuery({
   args: { emailIds: v.array(v.id("emails")) },
   handler: async (ctx, args) => {
-    const emails = await Promise.all(args.emailIds.map((id) => ctx.db.get("emails", id)));
+    const emails = await Promise.all(
+      args.emailIds.map((id) => ctx.db.get("emails", id)),
+    );
 
     // Some emails might be missing b/c they were cancelled long ago and already
     // cleaned up because the retention period has passed.

--- a/src/component/shared.ts
+++ b/src/component/shared.ts
@@ -1,5 +1,6 @@
 import { literals } from "convex-helpers/validators";
 import {
+  type GenericActionCtx,
   type GenericDataModel,
   type GenericMutationCtx,
   type GenericQueryCtx,
@@ -166,9 +167,12 @@ export type EventEventOfType<T extends EventEventTypes> = Extract<
 
 /* Type utils follow */
 
-export type RunQueryCtx = {
-  runQuery: GenericQueryCtx<GenericDataModel>["runQuery"];
-};
-export type RunMutationCtx = {
-  runMutation: GenericMutationCtx<GenericDataModel>["runMutation"];
-};
+export type QueryCtx = Pick<GenericQueryCtx<GenericDataModel>, "runQuery">;
+export type MutationCtx = Pick<
+  GenericMutationCtx<GenericDataModel>,
+  "runQuery" | "runMutation"
+>;
+export type ActionCtx = Pick<
+  GenericActionCtx<GenericDataModel>,
+  "runQuery" | "runMutation" | "runAction"
+>;


### PR DESCRIPTION
The context types accepted by public API methods have been expanded to be more permissive. Previously, `sendEmail`, `cancelEmail`, `sendEmailManually`, and `handleResendEventWebhook` only accepted a mutation context, and `status` and `get` only accepted a query context. These methods now also accept an action context, allowing them to be called from Convex actions in addition to mutations and queries.

The internal `RunQueryCtx` and `RunMutationCtx` types, which only exposed a single `runQuery` or `runMutation` method respectively, have been replaced with `QueryCtx`, `MutationCtx`, and `ActionCtx` types. `MutationCtx` now includes both `runQuery` and `runMutation`, and `ActionCtx` includes `runQuery`, `runMutation`, and `runAction`, reflecting the full capabilities of each context type.