### PR TITLE
forward message_id from Resend webhook payloads to onEmailEvent

### DIFF
--- a/src/component/lib.test.ts
+++ b/src/component/lib.test.ts
@@ -1,6 +1,7 @@
 import { expect, describe, it, beforeEach } from "vitest";
 import { api } from "./_generated/api.js";
-import type { EmailEvent } from "./shared.js";
+import { vEmailEvent, type EmailEvent } from "./shared.js";
+import { attemptToParse } from "./utils.js";
 import {
   createTestEventOfType,
   insertTestSentEmail,
@@ -246,6 +247,22 @@ describe("handleEmailEvent", () => {
     expect(updatedEmail.finalizedAt).toBe(Number.MAX_SAFE_INTEGER);
     expect(updatedEmail.complained).toBe(false);
     expect(updatedEmail.opened).toBe(false);
+  });
+});
+
+describe("vEmailEvent parsing", () => {
+  it("keeps message_id but strips unknown fields", () => {
+    const sent = createTestEventOfType("email.sent");
+    const rawWebhook = {
+      ...sent,
+      data: { ...sent.data, some_future_resend_field: "should be stripped" },
+    };
+
+    const result = attemptToParse(vEmailEvent, rawWebhook as unknown);
+    if (result.kind !== "success") throw new Error(String(result.error));
+
+    expect(result.data.data.message_id).toBe("<test-message-id@example.com>");
+    expect("some_future_resend_field" in result.data.data).toBe(false);
   });
 });
 

--- a/src/component/setup.test.ts
+++ b/src/component/setup.test.ts
@@ -27,6 +27,7 @@ export const createTestEventOfType = <T extends EventEventTypes>(
 ): EventEventOfType<T> => {
   const baseData = {
     email_id: "test-resend-id-123",
+    message_id: "<test-message-id@example.com>",
     created_at: "2024-01-01T00:00:00Z",
     from: "test@example.com",
     to: "recipient@example.com",

--- a/src/component/shared.ts
+++ b/src/component/shared.ts
@@ -52,6 +52,7 @@ const commonFields = {
   cc: v.optional(v.union(v.string(), v.array(v.string()))),
   bcc: v.optional(v.union(v.string(), v.array(v.string()))),
   reply_to: v.optional(v.union(v.string(), v.array(v.string()))),
+  message_id: v.optional(v.string()), // RFC Message-ID header, e.g. "<abc123@mail.example>"
   headers: v.optional(
     v.array(
       v.object({


### PR DESCRIPTION
👋 Claude here (on behalf of @hibukki)

Fixes #100.

Resend includes `message_id` (the RFC Message-ID header) in every `email.*` webhook payload, but the component dropped it: `handleEmailEvent` parses the raw webhook with `attemptToParse(vEmailEvent, …)`, which strips fields absent from the validator, and `vEmailEvent`'s event data had no `message_id`. So an app threading replies — a reply cites the original `message_id` in `In-Reply-To`/`References` — couldn't get it without an extra `GET /emails/:id`.

This adds `message_id: v.optional(v.string())` to `commonFields`, the shared shape spread into all eight `email.*` variants, so it survives parsing and reaches the `onEmailEvent` callback. `v.optional` keeps events queued before Resend added the field (or any variant without it) valid; and since the client reuses `vEmailEvent` as the callback's arg validator, the same one line also lets the user-side handler accept it.

> Yes that PR would be very welcome, thanks!

— @ianmacartney

## Changes
- `shared.ts`: `message_id` on `commonFields`
- test factory + a regression test asserting `attemptToParse` keeps `message_id` while stripping unknown fields

Left `CHANGELOG.md` alone since versions look maintainer-managed — happy to add an entry if you'd prefer.
