### PR TITLE
Upgrade Convex environment variable configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,11 @@ npm install @convex-dev/resend
 ## Get Started
 
 Create a [Resend](https://resend.com) account and grab an API key. Set it as
-`RESEND_API_KEY` in your Convex deployment.
+`RESEND_API_KEY` in your Convex deployment via
+
+```bash
+npx convex env set RESEND_API_KEY
+```
 
 Next, add the component to your Convex app via `convex/convex.config.ts`:
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ import resend from "@convex-dev/resend/convex.config.js";
 const app = defineApp({
   env: {
     RESEND_API_KEY: v.string(),
-    RESEND_WEBHOOK_SECRET: v.optional(v.string()),
   },
 });
 app.use(resend);
@@ -60,7 +59,6 @@ import { env, internalMutation } from "./_generated/server";
 
 export const resend: Resend = new Resend(components.resend, {
   apiKey: env.RESEND_API_KEY,
-  webhookSecret: env.RESEND_WEBHOOK_SECRET,
 });
 
 export const sendTestEmail = internalMutation({
@@ -122,8 +120,44 @@ project running at `https://happy-leopard-123.convex.site/resend-webhook`.
 So navigate to the Resend dashboard and create a new webhook at that URL. Make
 sure to enable all the `email.*` events; the other event types will be ignored.
 
-Finally, copy the webhook secret out of the Resend dashboard and set it to the
-`RESEND_WEBHOOK_SECRET` environment variable in your Convex deployment.
+Now that you have your webhook secret, we need to add it to Convex.
+
+Step 1, Add the env variable to your convex deployment with:
+
+```bash
+npx convex env set RESEND_WEBHOOK_SECRET
+```
+
+Step 2, tell add the webhook to Convex's typed env variables (available in ^1.39.0) to convex/convex.config.ts:
+
+```typescript
+import { defineApp } from "convex/server";
+import { v } from "convex/values";
+import resend from "@convex-dev/resend/convex.config.js";
+
+const app = defineApp({
+  env: {
+    RESEND_API_KEY: v.string(),
+    RESEND_WEBHOOK_SECRET: v.string(),  // Add this
+  },
+});
+app.use(resend);
+
+export default app;
+```
+
+Then you can use the typed env variable when initializing your Resend client:
+
+```typescript
+import { components } from "./_generated/api";
+import { Resend } from "@convex-dev/resend";
+import { env } from "./_generated/server";
+
+export const resend: Resend = new Resend(components.resend, {
+  apiKey: env.RESEND_API_KEY,
+  webhookSecret: env.RESEND_WEBHOOK_SECRET,  // Like so
+});
+```
 
 You should now be seeing email status updates as Resend makes progress on your
 batches!

--- a/README.md
+++ b/README.md
@@ -174,7 +174,12 @@ Update your `sendEmails.ts` to look something like this:
 ```ts
 import { components, internal } from "./_generated/api";
 import { env, internalMutation } from "./_generated/server";
-import { vEmailId, vEmailEvent, Resend } from "@convex-dev/resend";
+import {
+  vEmailId,
+  vEmailEvent,
+  vOnEmailEventArgs,
+  Resend,
+} from "@convex-dev/resend";
 
 export const resend: Resend = new Resend(components.resend, {
   apiKey: env.RESEND_API_KEY,

--- a/README.md
+++ b/README.md
@@ -30,16 +30,22 @@ npm install @convex-dev/resend
 
 ## Get Started
 
-Create a [Resend](https://resend.com) account and grab an API key. Set it to
-`RESEND_API_KEY` in your deployment environment.
+Create a [Resend](https://resend.com) account and grab an API key. Set it as
+`RESEND_API_KEY` in your Convex deployment.
 
 Next, add the component to your Convex app via `convex/convex.config.ts`:
 
 ```ts
 import { defineApp } from "convex/server";
+import { v } from "convex/values";
 import resend from "@convex-dev/resend/convex.config.js";
 
-const app = defineApp();
+const app = defineApp({
+  env: {
+    RESEND_API_KEY: v.string(),
+    RESEND_WEBHOOK_SECRET: v.optional(v.string()),
+  },
+});
 app.use(resend);
 
 export default app;
@@ -50,9 +56,12 @@ Then you can use it, as we see in `convex/sendEmails.ts`:
 ```ts
 import { components } from "./_generated/api";
 import { Resend } from "@convex-dev/resend";
-import { internalMutation } from "./_generated/server";
+import { env, internalMutation } from "./_generated/server";
 
-export const resend: Resend = new Resend(components.resend, {});
+export const resend: Resend = new Resend(components.resend, {
+  apiKey: env.RESEND_API_KEY,
+  webhookSecret: env.RESEND_WEBHOOK_SECRET,
+});
 
 export const sendTestEmail = internalMutation({
   handler: async (ctx) => {
@@ -130,10 +139,12 @@ Update your `sendEmails.ts` to look something like this:
 
 ```ts
 import { components, internal } from "./_generated/api";
-import { internalMutation } from "./_generated/server";
+import { env, internalMutation } from "./_generated/server";
 import { vEmailId, vEmailEvent, Resend } from "@convex-dev/resend";
 
 export const resend: Resend = new Resend(components.resend, {
+  apiKey: env.RESEND_API_KEY,
+  webhookSecret: env.RESEND_WEBHOOK_SECRET,
   onEmailEvent: internal.example.handleEmailEvent,
 });
 
@@ -156,9 +167,10 @@ customize it's behavior.
 
 Check out the [docstrings](./src/client/index.ts), but notable options include:
 
-- `apiKey`: Provide the Resend API key instead of having it read from the
-  environment variable.
-- `webhookSecret`: Same thing, but for the webhook secret.
+- `apiKey`: The Resend API key. Pass the typed `env.RESEND_API_KEY` value
+  declared in `convex.config.ts`.
+- `webhookSecret`: The optional webhook secret. Pass the typed
+  `env.RESEND_WEBHOOK_SECRET` value when using webhooks.
 - `testMode`: Only allow delivery to test addresses. To keep you safe as you
   develop your project, `testMode` is default **true**. You need to explicitly
   set this to `false` for the component to allow you to enqueue emails to
@@ -318,13 +330,14 @@ Then create a new .tsx file in your Convex directory e.g. `/convex/emails.tsx`:
 ```tsx
 // IMPORTANT: this is a Convex Node Action
 "use node";
-import { action } from "./_generated/server";
+import { action, env } from "./_generated/server";
 import { render, pretty } from "@react-email/render";
 import { Button, Html } from "@react-email/components";
 import { components } from "./_generated/api";
 import { Resend } from "@convex-dev/resend";
 
 export const resend: Resend = new Resend(components.resend, {
+  apiKey: env.RESEND_API_KEY,
   testMode: false,
 });
 
@@ -376,13 +389,15 @@ progress using the component's status and webhook APIs.
 
 ```ts
 import { components, internal } from "./_generated/api";
-import { internalAction } from "./_generated/server";
+import { env, internalAction } from "./_generated/server";
 import { Resend as ResendComponent } from "@convex-dev/resend";
 import { Resend } from "resend";
 
-const resendSdk = new Resend("re_xxxxxxxxx");
+const resendSdk = new Resend(env.RESEND_API_KEY);
 
-export const resend = new ResendComponent(components.resend, {});
+export const resend = new ResendComponent(components.resend, {
+  apiKey: env.RESEND_API_KEY,
+});
 
 export const sendManualEmail = internalAction({
   args: {},

--- a/example/convex/_generated/server.d.ts
+++ b/example/convex/_generated/server.d.ts
@@ -22,6 +22,14 @@ import {
 import type { DataModel } from "./dataModel.js";
 
 /**
+ * Typesafe environment variables declared in `convex.config.ts`.
+ */
+type Env = {
+  readonly RESEND_API_KEY: string;
+  readonly RESEND_WEBHOOK_SECRET: string | undefined;
+};
+
+/**
  * Define a query in this Convex app's public API.
  *
  * This function will be allowed to read your Convex database and will be accessible from the client.
@@ -94,6 +102,11 @@ export declare const internalAction: ActionBuilder<DataModel, "internal">;
  * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
  */
 export declare const httpAction: HttpActionBuilder;
+
+/**
+ * Typesafe environment variables declared in `convex.config.ts`.
+ */
+export declare const env: Env;
 
 /**
  * A set of services for use within Convex query functions.

--- a/example/convex/_generated/server.js
+++ b/example/convex/_generated/server.js
@@ -91,3 +91,8 @@ export const internalAction = internalActionGeneric;
  * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
  */
 export const httpAction = httpActionGeneric;
+
+/**
+ * Typesafe environment variables declared in `convex.config.ts`.
+ */
+export const env = process.env;

--- a/example/convex/convex.config.ts
+++ b/example/convex/convex.config.ts
@@ -1,7 +1,13 @@
 import { defineApp } from "convex/server";
+import { v } from "convex/values";
 import resend from "@convex-dev/resend/convex.config";
 
-const app = defineApp();
+const app = defineApp({
+  env: {
+    RESEND_API_KEY: v.string(),
+    RESEND_WEBHOOK_SECRET: v.optional(v.string()),
+  },
+});
 app.use(resend);
 
 export default app;

--- a/example/convex/example.ts
+++ b/example/convex/example.ts
@@ -2,15 +2,18 @@ import {
   internalMutation,
   internalAction,
   internalQuery,
+  env,
 } from "./_generated/server";
 import { components, internal } from "./_generated/api";
 import { Resend, vOnEmailEventArgs } from "@convex-dev/resend";
 import { v } from "convex/values";
 import { Resend as ResendSdk, Tag} from "resend";
 
-const resendSdk = new ResendSdk(process.env.RESEND_API_KEY!);
+const resendSdk = new ResendSdk(env.RESEND_API_KEY);
 
 export const resend: Resend = new Resend(components.resend, {
+  apiKey: env.RESEND_API_KEY,
+  webhookSecret: env.RESEND_WEBHOOK_SECRET,
   onEmailEvent: internal.example.handleEmailEvent,
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "vitest": "4.1.10"
       },
       "peerDependencies": {
-        "convex": "^1.31.7",
+        "convex": "^1.39.0",
         "convex-helpers": "^0.1.106"
       }
     },

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     }
   },
   "peerDependencies": {
-    "convex": "^1.31.7",
+    "convex": "^1.39.0",
     "convex-helpers": "^0.1.106"
   },
   "devDependencies": {

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -40,26 +40,14 @@ type Config = RuntimeConfig & {
   webhookSecret: string;
 };
 
-function getDefaultConfig(): Config {
-  return {
-    apiKey: process.env.RESEND_API_KEY ?? "",
-    webhookSecret: process.env.RESEND_WEBHOOK_SECRET ?? "",
-    initialBackoffMs: 30000,
-    retryAttempts: 5,
-    testMode: true,
-  };
-}
-
 export type ResendOptions = {
   /**
    * The API key to use for the Resend API.
-   * If not provided, the API key will be read from the environment variable RESEND_API_KEY.
    */
-  apiKey?: string;
+  apiKey: string;
 
   /**
    * The secret to use for the Resend webhook.
-   * If not provided, the webhook secret will be read from the environment variable RESEND_WEBHOOK_SECRET.
    */
   webhookSecret?: string;
 
@@ -216,18 +204,16 @@ export class Resend {
    */
   constructor(
     public component: ComponentApi,
-    options?: ResendOptions,
+    options: ResendOptions,
   ) {
-    const defaultConfig = getDefaultConfig();
     this.config = {
-      apiKey: options?.apiKey ?? defaultConfig.apiKey,
-      webhookSecret: options?.webhookSecret ?? defaultConfig.webhookSecret,
-      initialBackoffMs:
-        options?.initialBackoffMs ?? defaultConfig.initialBackoffMs,
-      retryAttempts: options?.retryAttempts ?? defaultConfig.retryAttempts,
-      testMode: options?.testMode ?? defaultConfig.testMode,
+      apiKey: options.apiKey,
+      webhookSecret: options.webhookSecret ?? "",
+      initialBackoffMs: options.initialBackoffMs ?? 30000,
+      retryAttempts: options.retryAttempts ?? 5,
+      testMode: options.testMode ?? true,
     };
-    if (options?.onEmailEvent) {
+    if (options.onEmailEvent) {
       this.onEmailEvent = options.onEmailEvent;
     }
   }


### PR DESCRIPTION
- Upgrade Convex peer dependency to ^1.39.0
- Pass typed environment variables into Resend configuration
- Document the new environment configuration workflow

This PR implements Convex's new env variable handling into the Resend component.  This change isn't exactly backwards compatible, so I'm not sure what the process is there (maybe a new major release like [PostHog](https://github.com/PostHog/posthog-js/blob/main/packages/convex/CHANGELOG.md#200)).  The implementation is super simple and straight forward.


<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
