### PR TITLE
Type the email event mutation argument

### DIFF
--- a/src/component/lib.test.ts
+++ b/src/component/lib.test.ts
@@ -24,7 +24,9 @@ describe("handleEmailEvent", () => {
   });
 
   const exec = async (_event: EmailEvent | unknown = event) => {
-    await t.mutation(api.lib.handleEmailEvent, { event: _event });
+    await t.mutation(api.lib.handleEmailEvent, {
+      event: _event as EmailEvent,
+    });
   };
 
   const getEmail = () =>

--- a/src/component/lib.ts
+++ b/src/component/lib.ts
@@ -1,4 +1,4 @@
-import { v } from "convex/values";
+import { v, type VAny } from "convex/values";
 import {
   internalAction,
   mutation,
@@ -911,7 +911,7 @@ function computeEmailUpdateFromEvent(
 // Handle a webhook event. Mostly we just update the email status.
 export const handleEmailEvent = mutation({
   args: {
-    event: v.any(),
+    event: v.any() as VAny<EmailEvent>,
   },
   returns: v.null(),
   handler: async (ctx, args) => {


### PR DESCRIPTION
This PR adds a type cast for the `event` parameter of the `handleEmailEvent` mutation.  It doesn't change the runtime at all just the type of the `event` param.
