### PR TITLE
feat: drive email batching with the batch-worker component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.2.8",
       "license": "Apache-2.0",
       "dependencies": {
+        "@convex-dev/batch-worker": "^0.3.4",
         "@convex-dev/rate-limiter": "^0.3.0",
         "@convex-dev/workpool": "^0.4.10",
         "remeda": "^2.26.0",
@@ -23,8 +24,8 @@
         "@types/node": "24.13.3",
         "@types/react": "19.2.17",
         "chokidar-cli": "3.0.0",
-        "convex": "1.44.0",
-        "convex-test": "0.0.54",
+        "convex": "1.45.0",
+        "convex-test": "0.0.56",
         "eslint": "10.7.0",
         "eslint-plugin-react-hooks": "7.1.1",
         "eslint-plugin-react-refresh": "0.5.3",
@@ -304,13 +305,15 @@
       }
     },
     "node_modules/@convex-dev/batch-worker": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@convex-dev/batch-worker/-/batch-worker-0.2.1.tgz",
-      "integrity": "sha512-QEDW6XmT+SmBJAmNqyl0QAEmJ4yMKJAIoJ+LntsA8KY5gYP+UhSFvTEMCvo177RZxOR/cfkZ3R+4S/UBaj/JnQ==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@convex-dev/batch-worker/-/batch-worker-0.3.4.tgz",
+      "integrity": "sha512-CKeOrPFsPoIKozMNP/qKExSwE6vd63QDKbZIbchK+P3S7fyGuFjRLbTg6+QmC/mzOjn6I5N8zo+k/SdXqeaA2g==",
       "license": "Apache-2.0",
+      "dependencies": {
+        "convex-helpers": "^0.1.119"
+      },
       "peerDependencies": {
-        "convex": "^1.36.1",
-        "react": "^18.3.1 || ^19.0.0"
+        "convex": "^1.43.0"
       }
     },
     "node_modules/@convex-dev/eslint-plugin": {
@@ -546,6 +549,16 @@
       "peerDependencies": {
         "convex": "^1.36.1",
         "convex-helpers": "^0.1.94"
+      }
+    },
+    "node_modules/@convex-dev/workpool/node_modules/@convex-dev/batch-worker": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@convex-dev/batch-worker/-/batch-worker-0.2.2.tgz",
+      "integrity": "sha512-3knigElzTVhWw1sN28EYkGBTdrJZ03vMj2PJPuFq3V0Tg41i7tcv/EWDBFQWcUaKzBWWVw693hcJtxCF3CRtEw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "convex": "^1.36.1",
+        "react": "^18.3.1 || ^19.0.0"
       }
     },
     "node_modules/@edge-runtime/primitives": {
@@ -2066,9 +2079,9 @@
       "license": "MIT"
     },
     "node_modules/convex": {
-      "version": "1.44.0",
-      "resolved": "https://registry.npmjs.org/convex/-/convex-1.44.0.tgz",
-      "integrity": "sha512-84bBa1ufSX4qohXdycXuQl2c2kAmfVpTCpypcmIgxpS5rUBgv5qjhArYugTkJVbljMs5SH2mW30bjJo+SQwe1w==",
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/convex/-/convex-1.45.0.tgz",
+      "integrity": "sha512-AV3B56Ptu/14d76g3urBJ50dwpiZa6uJaLT84OWox5aCwZIJiuAamdjv3lLHDzs8vv5kC31anEZohhUe3qJ2bA==",
       "license": "Apache-2.0",
       "dependencies": {
         "esbuild": "0.27.0",
@@ -2079,7 +2092,7 @@
         "convex": "bin/main.js"
       },
       "engines": {
-        "node": ">=18.0.0",
+        "node": ">=20.0.0",
         "npm": ">=7.0.0"
       },
       "peerDependencies": {
@@ -2104,20 +2117,19 @@
       }
     },
     "node_modules/convex-helpers": {
-      "version": "0.1.106",
-      "resolved": "https://registry.npmjs.org/convex-helpers/-/convex-helpers-0.1.106.tgz",
-      "integrity": "sha512-hWRe3yDaAVHMe4CUYw1YoQLiPZ1KIx6Kbf0w6UcRDx1BXpJgMCl3GVIMiSeYiA0PkbwjnIwGWIvoUVKloG5Tyw==",
+      "version": "0.1.123",
+      "resolved": "https://registry.npmjs.org/convex-helpers/-/convex-helpers-0.1.123.tgz",
+      "integrity": "sha512-E9W4tscZy6ZtNnwPDdL5UhMc7Rj9aUYlzjdYiKsfVIAwdarABWqvPB8+St3Q6IwS83r+QIGSO1lTidTamDdyPQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "convex-helpers": "bin.cjs"
       },
       "peerDependencies": {
         "@standard-schema/spec": "^1.0.0",
-        "convex": "^1.25.4",
+        "convex": "^1.43.0",
         "hono": "^4.0.5",
         "react": "^17.0.2 || ^18.0.0 || ^19.0.0",
-        "typescript": "^5.5",
+        "typescript": "^5.5 || ^6.0.0 || ^7.0.0",
         "zod": "^3.25.0 || ^4.0.0"
       },
       "peerDependenciesMeta": {
@@ -2139,13 +2151,13 @@
       }
     },
     "node_modules/convex-test": {
-      "version": "0.0.54",
-      "resolved": "https://registry.npmjs.org/convex-test/-/convex-test-0.0.54.tgz",
-      "integrity": "sha512-C0v2SQcuxrELAJRNzE6fQ686XDPor7UFoC22jcoJXeCRqhLo8ZIMZ4jyUHoo1UdAL2enCb0AbiprCVpLDN8u9Q==",
+      "version": "0.0.56",
+      "resolved": "https://registry.npmjs.org/convex-test/-/convex-test-0.0.56.tgz",
+      "integrity": "sha512-dLYXlQjKFoGqvjAmPzyLgb2HsYI7iLo1iuNTU2DZmSrMRLWosYk94erjSU67GG5ovfP6+MjX8RJO+ebhmL6QYA==",
       "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
-        "convex": "^1.32.0"
+        "convex": "^1.43.0"
       }
     },
     "node_modules/convex/node_modules/@esbuild/aix-ppc64": {

--- a/package.json
+++ b/package.json
@@ -69,8 +69,8 @@
     "@types/node": "24.13.3",
     "@types/react": "19.2.17",
     "chokidar-cli": "3.0.0",
-    "convex": "1.44.0",
-    "convex-test": "0.0.54",
+    "convex": "1.45.0",
+    "convex-test": "0.0.56",
     "eslint": "10.7.0",
     "eslint-plugin-react-hooks": "7.1.1",
     "eslint-plugin-react-refresh": "0.5.3",
@@ -87,6 +87,7 @@
   "types": "./dist/client/index.d.ts",
   "module": "./dist/client/index.js",
   "dependencies": {
+    "@convex-dev/batch-worker": "^0.3.4",
     "@convex-dev/rate-limiter": "^0.3.0",
     "@convex-dev/workpool": "^0.4.10",
     "remeda": "^2.26.0",

--- a/src/component/_generated/api.ts
+++ b/src/component/_generated/api.ts
@@ -55,4 +55,5 @@ export const components = componentsGeneric() as unknown as {
   rateLimiter: import("@convex-dev/rate-limiter/_generated/component.js").ComponentApi<"rateLimiter">;
   emailWorkpool: import("@convex-dev/workpool/_generated/component.js").ComponentApi<"emailWorkpool">;
   callbackWorkpool: import("@convex-dev/workpool/_generated/component.js").ComponentApi<"callbackWorkpool">;
+  batchWorker: import("@convex-dev/batch-worker/_generated/component.js").ComponentApi<"batchWorker">;
 };

--- a/src/component/batching.test.ts
+++ b/src/component/batching.test.ts
@@ -1,0 +1,124 @@
+/// <reference types="vite/client" />
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { convexTest } from "convex-test";
+import batchWorker from "@convex-dev/batch-worker/test";
+import workpool from "@convex-dev/workpool/test";
+import rateLimiter from "@convex-dev/rate-limiter/test";
+import schema from "./schema.js";
+import { api } from "./_generated/api.js";
+import { createTestRuntimeConfig, modules } from "./setup.test.js";
+
+// Register every child component so we can drive the whole pipeline:
+// batch worker loop -> worker mutation -> workpool action -> Resend API.
+const setupPipelineTest = () => {
+  const t = convexTest(schema, modules);
+  batchWorker.register(t, "batchWorker");
+  workpool.register(t, "emailWorkpool");
+  workpool.register(t, "callbackWorkpool");
+  rateLimiter.register(t, "rateLimiter");
+  return t;
+};
+
+describe("email batching pipeline", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("drains a waiting email through the batch worker and workpool", async () => {
+    vi.useFakeTimers();
+    const t = setupPipelineTest();
+
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ data: [{ id: "re_batch_123" }] }), {
+          status: 200,
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const emailId = await t.mutation(api.lib.sendEmail, {
+      options: createTestRuntimeConfig(),
+      from: "onboarding@resend.dev",
+      to: ["delivered@resend.dev"],
+      subject: "Hello",
+      html: "<p>Hi there</p>",
+    });
+
+    let email = await t.run(async (ctx) => ctx.db.get("emails", emailId));
+    expect(email?.status).toBe("waiting");
+
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    email = await t.run(async (ctx) => ctx.db.get("emails", emailId));
+    expect(email?.status).toBe("sent");
+    expect(email?.resendId).toBe("re_batch_123");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("picks up emails sent after the cursor has advanced", async () => {
+    vi.useFakeTimers();
+    const t = setupPipelineTest();
+
+    let batch = 0;
+    const fetchMock = vi.fn(async (_url: unknown, init?: RequestInit) => {
+      const payload = JSON.parse(init!.body as string) as unknown[];
+      const ids = payload.map(() => ({ id: `re_batch_${batch++}` }));
+      return new Response(JSON.stringify({ data: ids }), { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const sendOne = (subject: string) =>
+      t.mutation(api.lib.sendEmail, {
+        options: createTestRuntimeConfig(),
+        from: "onboarding@resend.dev",
+        to: ["delivered@resend.dev"],
+        subject,
+        html: "<p>Hi there</p>",
+      });
+
+    // First email drains fully, advancing the worker's cursor.
+    const firstId = await sendOne("First");
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    // A later email commits after the cursor; the next scan must find it.
+    const secondId = await sendOne("Second");
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const [first, second] = await t.run(async (ctx) => [
+      await ctx.db.get("emails", firstId),
+      await ctx.db.get("emails", secondId),
+    ]);
+    expect(first?.status).toBe("sent");
+    expect(second?.status).toBe("sent");
+    expect(second?.resendId).not.toBe(first?.resendId);
+  });
+
+  it("does not send emails cancelled while waiting", async () => {
+    vi.useFakeTimers();
+    const t = setupPipelineTest();
+
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ data: [{ id: "re_batch_456" }] }), {
+          status: 200,
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const emailId = await t.mutation(api.lib.sendEmail, {
+      options: createTestRuntimeConfig(),
+      from: "onboarding@resend.dev",
+      to: ["delivered@resend.dev"],
+      subject: "Hello",
+      html: "<p>Hi there</p>",
+    });
+    await t.mutation(api.lib.cancelEmail, { emailId });
+
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const email = await t.run(async (ctx) => ctx.db.get("emails", emailId));
+    expect(email?.status).toBe("cancelled");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/component/convex.config.ts
+++ b/src/component/convex.config.ts
@@ -1,10 +1,12 @@
 import { defineComponent } from "convex/server";
 import rateLimiter from "@convex-dev/rate-limiter/convex.config";
 import workpool from "@convex-dev/workpool/convex.config";
+import batchWorker from "@convex-dev/batch-worker/convex.config";
 
 const component = defineComponent("resend");
 component.use(rateLimiter);
 component.use(workpool, { name: "emailWorkpool" });
 component.use(workpool, { name: "callbackWorkpool" });
+component.use(batchWorker);
 
 export default component;

--- a/src/component/lib.ts
+++ b/src/component/lib.ts
@@ -9,6 +9,7 @@ import {
 } from "./_generated/server.js";
 import { Workpool } from "@convex-dev/workpool";
 import { RateLimiter } from "@convex-dev/rate-limiter";
+import { defineBatchWorkerValidators, ping } from "@convex-dev/batch-worker";
 import { api, components, internal } from "./_generated/api.js";
 import { internalMutation } from "./_generated/server.js";
 import { type Id, type Doc } from "./_generated/dataModel.js";
@@ -25,11 +26,10 @@ import type { EmailEvent } from "./shared.js";
 import { isDeepEqual } from "remeda";
 import schema from "./schema.js";
 import { omit } from "convex-helpers";
-import { parse } from "convex-helpers/validators";
+import { doc, parse } from "convex-helpers/validators";
 import { assertExhaustive, attemptToParse } from "./utils.js";
 
 // Move some of these to options? TODO
-const SEGMENT_MS = 125;
 const BASE_BATCH_DELAY = 1000;
 const BATCH_SIZE = 100;
 const EMAIL_POOL_SIZE = 4;
@@ -64,11 +64,6 @@ const PERMANENT_ERROR_CODES = new Set([
   422 /*423, 424, 425, may change over time */, 426, 427,
   428 /* 429, explicitly asked to retry */, 431 /* 451, laws change? */,
 ]);
-
-// We break the emails into segments to avoid contention on new emails being inserted.
-function getSegment(now: number) {
-  return Math.floor(now / SEGMENT_MS);
-}
 
 // Four threads is more than enough, especially given the low rate limiting.
 const emailPool = new Workpool(components.emailWorkpool, {
@@ -203,10 +198,7 @@ export const sendEmail = mutation({
       textContentId = contentId;
     }
 
-    // This is the "send requested" segment.
-    const segment = getSegment(Date.now());
-
-    // Okay, we're ready to insert the email into the database, waiting for a background job to enqueue it.
+    // Okay, we're ready to insert the email into the database, waiting for the batch worker to enqueue it.
     const emailId = await ctx.db.insert("emails", {
       from: args.from,
       to: args.to,
@@ -218,7 +210,7 @@ export const sendEmail = mutation({
       template: args.template,
       headers: args.headers,
       idempotencyKey: args.idempotencyKey,
-      segment,
+      insertedAt: ctx.db.vars.commitTs,
       status: "waiting",
       bounced: false,
       complained: false,
@@ -262,7 +254,6 @@ export const createManualEmail = mutation({
       bcc: toArray(args.bcc),
       subject: args.subject,
       headers: args.headers,
-      segment: Infinity,
       status: "queued",
       bounced: false,
       complained: false,
@@ -416,32 +407,60 @@ async function scheduleBatchRun(ctx: MutationCtx, options: RuntimeConfig) {
     });
   }
 
-  // Check if there is already a worker running.
-  const existing = await ctx.db.query("nextBatchRun").unique();
+  await pingEmailWorker(ctx);
+}
 
-  // Is there already a worker running?
-  if (existing) {
-    return;
-  }
-
-  // No worker running? Schedule one.
-  const runId = await ctx.scheduler.runAfter(
-    BASE_BATCH_DELAY,
-    internal.lib.makeBatch,
-    { reloop: false, segment: getSegment(Date.now() + BASE_BATCH_DELAY) },
-  );
-
-  // Insert the new worker to reserve exactly one running.
-  await ctx.db.insert("nextBatchRun", {
-    runId,
+// Keep the email worker loop alive. Cheap and idempotent, so we call it on
+// every send.
+async function pingEmailWorker(ctx: MutationCtx) {
+  await ping(ctx, components.batchWorker, {
+    name: "emails",
+    workQuery: internal.lib.nextEmailBatch,
+    workerMutation: internal.lib.sendEmailBatch,
+    // Wait before the first batch so a burst of sends accumulates.
+    config: { debounceMs: BASE_BATCH_DELAY },
   });
 }
 
-// A background job that grabs batches of emails and enqueues them to be sent by the workpool.
-export const makeBatch = internalMutation({
-  args: { reloop: v.boolean(), segment: v.number() },
-  returns: v.null(),
-  handler: async (ctx, args) => {
+const { vQueryArgs, vQueryReturns, vMutationArgs, vMutationReturns } =
+  defineBatchWorkerValidators({
+    batch: { emails: v.array(doc(schema, "emails")) },
+  });
+
+// Decide the next batch of emails to send, or report that the queue is empty.
+export const nextEmailBatch = internalQuery({
+  args: vQueryArgs,
+  returns: vQueryReturns,
+  handler: async (ctx, { cursor }) => {
+    // Emails leave this index range once queued, so `gte` never hands out
+    // work twice; the cursor exists to skip the tombstones they leave behind.
+    const emails = await ctx.db
+      .query("emails")
+      .withIndex("by_status_insertedAt", (q) =>
+        cursor === undefined
+          ? q.eq("status", "waiting")
+          : q.eq("status", "waiting").gte("insertedAt", cursor),
+      )
+      .take(BATCH_SIZE);
+    if (emails.length === 0) {
+      return { kind: "idle" as const };
+    }
+    return {
+      kind: "work" as const,
+      batch: { emails },
+      // Emails from older versions have no insertedAt and sort first; for
+      // those, undefined leaves the cursor where it was until they drain.
+      cursor: emails[emails.length - 1].insertedAt,
+    };
+  },
+});
+
+// Process one batch: mark the emails as queued and hand them to the workpool,
+// which calls the Resend batch API in a durable background action with retries.
+export const sendEmailBatch = internalMutation({
+  args: vMutationArgs,
+  returns: vMutationReturns,
+  handler: async (ctx, { emails }) => {
     // Get the API key for the worker.
     const lastOptions = await ctx.db.query("lastOptions").unique();
     if (!lastOptions) {
@@ -449,24 +468,11 @@ export const makeBatch = internalMutation({
     }
     const options = lastOptions.options;
 
-    // Grab the batch of emails to send.
-    const emails = await ctx.db
-      .query("emails")
-      .withIndex("by_status_segment", (q) =>
-        // We scan earlier than two segments ago to avoid contention between new email insertions and batch creation.
-        q.eq("status", "waiting").lte("segment", args.segment - 2),
-      )
-      .take(BATCH_SIZE);
-
-    // If we have no emails, or we have a short batch on a reloop,
-    // let's delay working for now.
-    if (emails.length === 0 || (args.reloop && emails.length < BATCH_SIZE)) {
-      return reschedule(ctx, emails.length > 0);
-    }
-
     console.log(`Making a batch of ${emails.length} emails`);
 
-    // Mark the emails as queued.
+    // Mark the emails as queued. The batch comes from the same db snapshot as
+    // this mutation, and patching takes a read dependency on each doc, so a
+    // concurrent cancellation conflicts and re-runs the whole loop iteration.
     for (const email of emails) {
       await ctx.db.patch("emails", email._id, {
         status: "queued",
@@ -497,40 +503,23 @@ export const makeBatch = internalMutation({
       },
     );
 
-    // Let's go around again until there are no more batches to make in this particular segment range.
-    await ctx.scheduler.runAfter(0, internal.lib.makeBatch, {
-      reloop: true,
-      segment: args.segment,
-    });
+    // Full batch: drain immediately. Short batch: the queue is empty, so
+    // debounce to let the next burst accumulate.
+    return emails.length === BATCH_SIZE
+      ? null
+      : { debounceMs: BASE_BATCH_DELAY };
   },
 });
 
-// If there are no more emails to send in this segment range, we need to check to see if there are any
-// emails in newer segments and so we should sleep for a bit before trying to make batches again.
-// If the table is empty, we need to stop the worker and idle the system until a new email is inserted.
-async function reschedule(ctx: MutationCtx, emailsLeft: boolean) {
-  emailsLeft =
-    emailsLeft ||
-    (await ctx.db
-      .query("emails")
-      .withIndex("by_status_segment", (q) => q.eq("status", "waiting"))
-      .first()) !== null;
-
-  if (!emailsLeft) {
-    // No next email yet?
-    const batchRun = await ctx.db.query("nextBatchRun").unique();
-    if (!batchRun) {
-      throw new Error("No batch run found -- invariant");
-    }
-    await ctx.db.delete("nextBatchRun", batchRun._id);
-  } else {
-    const segment = getSegment(Date.now() + BASE_BATCH_DELAY);
-    await ctx.scheduler.runAfter(BASE_BATCH_DELAY, internal.lib.makeBatch, {
-      reloop: false,
-      segment,
-    });
-  }
-}
+// Migration shim: older versions scheduled this directly, so an upgrading
+// deployment may have a run in flight. Hand the queue to the batch worker.
+export const makeBatch = internalMutation({
+  args: { reloop: v.boolean(), segment: v.number() },
+  returns: v.null(),
+  handler: async (ctx) => {
+    await pingEmailWorker(ctx);
+  },
+});
 
 // Helper to fetch content. We'll use batch apis here to avoid lots of action->query calls.
 async function getAllContent(

--- a/src/component/schema.ts
+++ b/src/component/schema.ts
@@ -9,9 +9,6 @@ export default defineSchema({
     filename: v.optional(v.string()),
     path: v.optional(v.string()),
   }),
-  nextBatchRun: defineTable({
-    runId: v.id("_scheduled_functions"),
-  }),
   lastOptions: defineTable({
     options: vOptions,
   }),
@@ -50,10 +47,15 @@ export default defineSchema({
     clicked: v.optional(v.boolean()),
     resendId: v.optional(v.string()),
     idempotencyKey: v.optional(v.string()),
-    segment: v.number(),
+    // Deprecated: only written by older versions, for their batching loop.
+    segment: v.optional(v.number()),
+    // Commit timestamp of the insert: the batch worker's cursor over waiting
+    // emails. Optional because older versions didn't write it; missing values
+    // sort before all timestamps, so those emails drain first.
+    insertedAt: v.optional(v.commitTs()),
     finalizedAt: v.number(),
   })
-    .index("by_status_segment", ["status", "segment"])
+    .index("by_status_insertedAt", ["status", "insertedAt"])
     .index("by_resendId", ["resendId"])
     .index("by_idempotencyKey", ["idempotencyKey"])
     .index("by_finalizedAt", ["finalizedAt"]),

--- a/src/component/setup.test.ts
+++ b/src/component/setup.test.ts
@@ -6,6 +6,7 @@ import type {
   RuntimeConfig,
 } from "./shared.js";
 import { convexTest } from "convex-test";
+import batchWorker from "@convex-dev/batch-worker/test";
 import schema from "./schema.js";
 import type { Doc } from "./_generated/dataModel.js";
 import { assertExhaustive } from "./utils.js";
@@ -14,6 +15,7 @@ export const modules = import.meta.glob("./**/*.*s");
 
 export const setupTest = () => {
   const t = convexTest(schema, modules);
+  batchWorker.register(t, "batchWorker");
   return t;
 };
 
@@ -199,7 +201,6 @@ export const insertTestSentEmail = (
     opened: false,
     clicked: false,
     resendId: "test-resend-id-123",
-    segment: 1,
     finalizedAt: Number.MAX_SAFE_INTEGER, // FINALIZED_EPOCH
     ...overrides,
   });


### PR DESCRIPTION
feat: drive email batching with the batch-worker component

Replace the hand-rolled batching loop (nextBatchRun bookkeeping,
makeBatch self-scheduling, and email segments) with
@convex-dev/batch-worker: sendEmail pings the worker, nextEmailBatch
decides the next batch of waiting emails, and sendEmailBatch marks
them queued and hands them to the workpool, which still calls the
Resend batch API with retries and rate limiting as before.

- Use defineBatchWorkerValidators so the batch shape and cursor type
  stay in sync between the work query and worker mutation. The batch
  carries full email docs; the mutation runs against the same db
  snapshot as the query, so no re-fetching.
- Track scan progress with a commit-timestamp cursor: emails gain an
  insertedAt v.commitTs() field and a by_status_insertedAt index, so
  each scan resumes past the tombstones of already-queued emails.
- Keep makeBatch as a migration shim so an upgrading deployment with a
  scheduled run in flight drains cleanly; keep nextBatchRun and
  segment (now optional) in the schema for upgrade compatibility.
- Bump the convex peer dependency to ^1.43.0 (required for
  v.commitTs), convex devDependency to 1.45.0, and convex-test to
  0.0.56.

test: cover the email batching pipeline end to end

Register the batchWorker, workpool, and rateLimiter components in
convex-test and drive the full flow with fake timers and a mocked
Resend API: waiting emails drain to sent with a resendId, emails
cancelled while waiting are never sent, and emails inserted after the
cursor has advanced are still picked up.